### PR TITLE
Set up login/logout functions

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -3,6 +3,7 @@ import { useMediaQuery } from "react-responsive";
 import { styled, css } from "@mui/material/styles";
 import { AppBar, IconButton, ListItem } from "@mui/material";
 import Router from "next/router";
+import axios from "axios";
 
 import { theme } from "../styles/theme";
 import {
@@ -110,7 +111,15 @@ const AvatarMenu = ({ avatarSrc, userName }) => {
 
   const handleLogOut = () => {
     console.log("logging out");
-    Router.push("/logged-out");
+    console.dir(axios.defaults.headers.common);
+    axios.delete('http://localhost:3001/logout', { // TODO: set base url in some variable that switches out based on env
+      }).then((res) => {
+        // TODO: update logged out state
+          console.log("successfully logged out");
+          axios.defaults.headers.common['Authorization'] = null;
+          console.dir(axios.defaults.headers.common);
+          Router.push("/logged-out");
+      }).catch((err) => console.error(err));
   };
 
   return (

--- a/components/Header.js
+++ b/components/Header.js
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useMediaQuery } from "react-responsive";
 import { styled, css } from "@mui/material/styles";
 import { AppBar, IconButton, ListItem } from "@mui/material";
+import Router from "next/router";
 
 import { theme } from "../styles/theme";
 import {
@@ -107,6 +108,11 @@ const AvatarMenu = ({ avatarSrc, userName }) => {
     }
   `;
 
+  const handleLogOut = () => {
+    console.log("logging out");
+    Router.push("/logged-out");
+  };
+
   return (
     <>
       <Avatar
@@ -136,7 +142,7 @@ const AvatarMenu = ({ avatarSrc, userName }) => {
         <NavLink secondary to="/user-profile" label="Your profile" />
         <NavLink secondary to="/school-profile" label="Your school" />
         <NavLink secondary to="/settings" label="Settings" />
-        <StyledOption onClick={undefined} hoverable>
+        <StyledOption onClick={handleLogOut} hoverable>
           <Typography lightened>Sign out</Typography>
         </StyledOption>
       </StyledUserMenu>

--- a/components/Header.js
+++ b/components/Header.js
@@ -112,12 +112,10 @@ const AvatarMenu = ({ avatarSrc, userName }) => {
   const handleLogOut = () => {
     console.log("logging out");
     console.dir(axios.defaults.headers.common);
-    axios.delete('http://localhost:3001/logout', { // TODO: set base url in some variable that switches out based on env
+    axios.delete('http://localhost:3001/logout', { withCredentials: true  // TODO: set base url in some variable that switches out based on env
       }).then((res) => {
         // TODO: update logged out state
           console.log("successfully logged out");
-          axios.defaults.headers.common['Authorization'] = null;
-          console.dir(axios.defaults.headers.common);
           Router.push("/logged-out");
       }).catch((err) => console.error(err));
   };

--- a/pages/login.js
+++ b/pages/login.js
@@ -14,6 +14,8 @@ import {
 } from "@ui";
 import Header from "@components/Header";
 
+let user = false;
+
 const PageContent = styled(Box)`
   flex-grow: 1;
   margin-top: ${({ theme }) => theme.util.appBarHeight}px;
@@ -32,7 +34,10 @@ const Login = ({}) => {
         password: data.password,
       },
     }).then(function (response) {
+      console.log("logged in");
+      console.log(response.headers.authorization);
       axios.defaults.headers.common['Authorization'] = response.headers.authorization 
+      user = true;
       // TODO: research if saving the JWT here is secure. can someone easily access this JWT?
       // TODO: update context state to be logged in
     }).catch(function (error) {
@@ -45,7 +50,7 @@ const Login = ({}) => {
 
   return (
     <>
-      <Header user={false} />
+      <Header user={user} />
       <PageContent>
         <Grid container alignItems="center" justifyContent="center">
           <Grid item xs={12} sm={6} md={4} lg={3}>

--- a/pages/login.js
+++ b/pages/login.js
@@ -14,7 +14,6 @@ import {
 } from "@ui";
 import Header from "@components/Header";
 
-let user = false;
 
 const PageContent = styled(Box)`
   flex-grow: 1;
@@ -28,18 +27,18 @@ const Login = ({}) => {
     formState: { errors, isSubmitSuccessful, isSubmitting },
   } = useForm();
   const onSubmit = (data) => {
-    axios.post('http://localhost:3001/login', { // TODO: set base url in some variable that switches out based on env
-      user: {
-        email: data.email,
-        password: data.password,
+    axios.post(
+      'http://localhost:3001/login', // TODO: set base url in some variable that switches out based on env
+      {
+        user:
+        {
+          email: data.email,
+          password: data.password,
+        }
       },
-    }).then(function (response) {
+      { withCredentials: true }
+    ).then(function (response) {
       console.log("logged in");
-      console.log(response.headers.authorization);
-      axios.defaults.headers.common['Authorization'] = response.headers.authorization 
-      user = true;
-      // TODO: research if saving the JWT here is secure. can someone easily access this JWT?
-      // TODO: update context state to be logged in
     }).catch(function (error) {
       // handle error
       console.log(error);
@@ -50,7 +49,7 @@ const Login = ({}) => {
 
   return (
     <>
-      <Header user={user} />
+      <Header user={false} />
       <PageContent>
         <Grid container alignItems="center" justifyContent="center">
           <Grid item xs={12} sm={6} md={4} lg={3}>

--- a/pages/login.js
+++ b/pages/login.js
@@ -25,9 +25,22 @@ const Login = ({}) => {
     handleSubmit,
     formState: { errors, isSubmitSuccessful, isSubmitting },
   } = useForm();
-  const onSubmit = (data) => console.log(data);
+  const onSubmit = (data) => {
+    axios.post('http://localhost:3001/login', { // TODO: set base url in some variable that switches out based on env
+      user: {
+        email: data.email,
+        password: data.password,
+      },
+    }).then(function (response) {
+      axios.defaults.headers.common['Authorization'] = response.headers.authorization 
+      // TODO: research if saving the JWT here is secure. can someone easily access this JWT?
+      // TODO: update context state to be logged in
+    }).catch(function (error) {
+      // handle error
+      console.log(error);
+    })
+  }
 
-  // console.log({ errors });
   const googleLogo = "/assets/images/google-g-logo.svg";
 
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -3852,7 +3852,7 @@ axe-core@^4.3.5:
 
 axios@^0.26.1:
   version "0.26.1"
-  resolved "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.1.tgz#1ede41c51fcf51bbbd6fd43669caaa4f0495aaa9"
   integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==
   dependencies:
     follow-redirects "^1.14.8"
@@ -6225,9 +6225,9 @@ flush-write-stream@^1.0.0:
     readable-stream "^2.3.6"
 
 follow-redirects@^1.14.8:
-  version "1.15.1"
-  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz"
-  integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
@taylorz I've tested this PR with this backend PR https://github.com/keithtom/wildflower-platform/pull/30. 

All requests need to be made with the `withCredentials: true` option. This sends the token w/ the httpOnly cookie back to the server for verification.

TODO:
- [ ] somehow dynamically set the url given the environment (local vs development)
- [ ] set state/context to be logged in/logged out for UI