### PR TITLE
Move all state and event handlers out of InfoDrawer and into Task component

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -4,7 +4,7 @@ import { styled, css } from "@mui/material/styles";
 import { AppBar, IconButton, ListItem } from "@mui/material";
 import Router from "next/router";
 import axios from "axios";
-import { getCookie, deleteCookie } from 'cookies-next';
+import { getCookie, deleteCookie } from "cookies-next";
 import { useUserContext } from "../lib/useUserContext";
 import { theme } from "../styles/theme";
 import {
@@ -16,7 +16,7 @@ import {
   Icon,
   NavLink,
 } from "./ui/index";
-import baseUrl from "../lib/utils/baseUrl"
+import baseUrl from "../lib/utils/baseUrl";
 
 const logoutRoute = `${baseUrl}/logout`;
 
@@ -111,27 +111,31 @@ const AvatarMenu = ({ avatarSrc, userName }) => {
   `;
 
   const StyledUserMenu = styled(Popover)`
+    margin-top: ${({ theme }) => theme.util.buffer * 2}px;
     .MuiPopover-paper {
       width: 240px;
     }
   `;
 
   const handleLogOut = () => {
-    axios.delete(logoutRoute)  // TODO: set base url in some variable that switches out based on env
+    axios
+      .delete(logoutRoute) // TODO: set base url in some variable that switches out based on env
       .then((res) => {
         // TODO: update logged out state
-          deleteCookie("auth", {});
-          delete axios.defaults.headers.common["Authorization"];
+        deleteCookie("auth", {});
+        delete axios.defaults.headers.common["Authorization"];
 
-          setCurrentUser(null);
+        setCurrentUser(null);
 
-          Router.push("/logged-out");
-      }).catch((err) => console.error(err));
+        Router.push("/logged-out");
+      })
+      .catch((err) => console.error(err));
   };
 
   return (
     <>
       <Avatar
+        hoverable
         size="sm"
         onClick={handleOpen}
         aria-describedby={id}
@@ -153,13 +157,15 @@ const AvatarMenu = ({ avatarSrc, userName }) => {
         }}
       >
         <StyledOption>
-          <Typography highlight>Signed in as {userName}</Typography>
+          <Typography variant="bodyRegular" lightened>
+            Signed in as {userName}
+          </Typography>
         </StyledOption>
         <NavLink secondary to="/user-profile" label="Your profile" />
         <NavLink secondary to="/school-profile" label="Your school" />
         <NavLink secondary to="/settings" label="Settings" />
         <StyledOption onClick={handleLogOut} hoverable>
-          <Typography lightened>Sign out</Typography>
+          <Typography variant="bodyRegular">Sign out</Typography>
         </StyledOption>
       </StyledUserMenu>
     </>

--- a/components/InfoDrawer.js
+++ b/components/InfoDrawer.js
@@ -1,10 +1,5 @@
-import { useState } from "react";
 import { styled } from "@mui/material/styles";
 import { Drawer } from "@mui/material";
-import { FormControlLabel, RadioGroup } from "@mui/material";
-import processesApi from "../api/processes";
-import stepsApi from "../api/steps";
-import { useUserContext } from "@lib/useUserContext";
 
 import {
   Card,
@@ -15,11 +10,7 @@ import {
   IconButton,
   Chip,
   Divider,
-  Button,
   Avatar,
-  Link,
-  Radio,
-  Snackbar,
 } from "./ui/index";
 import EffortChip from "./EffortChip";
 import CategoryChip from "./CategoryChip";
@@ -43,442 +34,129 @@ const CustomDrawer = styled(Drawer)`
 const InfoDrawer = ({
   toggle,
   open,
-  milestone,
-  task,
+  assignee,
   about,
+  taskId,
+  title,
+  status,
+  resources,
   categories,
-  handleCompleteTask,
+  effort,
+  actions,
+  isDecision,
+  isComplete,
 }) => {
-  const [userIsUpdatingDecision, setUserIsUpdatingDecision] = useState(false);
-  const [decisionOption, setDecisionOption] = useState();
-  const [isDecided, setIsDecided] = useState(false);
-  const [assignToastOpen, setAssignToastOpen] = useState(false);
-  const [unassignToastOpen, setUnassignToastOpen] = useState(false);
-  const [assignee, setAssignee] = useState(task && task.assignee);
-  const [taskIsComplete, setTaskIsComplete] = useState(task && task.isComplete);
-  const { currentUser } = useUserContext();
-
-  async function handleAssignSelf() {
-    try {
-      const response = await stepsApi.assign(task.id, currentUser.id);
-      setAssignee(currentUser)
-      // TODO: update UI for Taylor
-    } catch (err) {
-      console.error(err);
-    }
-
-    // console.log("assigning yourself");
-    // setAssignee(true); //assign the user
-    setAssignToastOpen(true);
-    //update the assignee on the task
-  };
-
-  async function handleUnassignSelf() {
-    try {
-      const response = await stepsApi.unassign(task.id);
-      setAssignee(null)
-      // TODO: update UI for Taylor
-    } catch (err) {
-      console.error(err);
-    }
-    // console.log("unassigning yourself");
-    setUnassignToastOpen(true);
-    //update the assignee on the task
-  };
-  const handleAskOpsGuide = () => {
-    console.log("ask ops guide");
-  };
-
-  const handleDecisionOptionChange = (e) => {
-    setDecisionOption(e.target.value);
-  };
-  const handleMakeDecision = () => {
-    setUserIsUpdatingDecision(false);
-    setIsDecided(true);
-    console.log("made a decision!");
-    //send decision to backend
-  };
-
-  async function handleCompleteTask() {
-    // api call, backend determiens state. needs spinner and error management.
-    try {
-      // if checking, complete, if unchecking, uncomplete.
-      const response = await processesApi.complete(task.id);
-      setTaskIsComplete(true); 
-      // TODO: update UI for Taylor
-    } catch (err) {
-      console.error(err);
-    }
-
-    if (task.isLast) {
-      // TODO: Taylor
-      // handleCompleteMilestone();
-    }
-  }
-
-  async function handleMarkTaskIncomplete() {
-    // api call, backend determiens state. needs spinner and error management.
-    try {
-      // if checking, complete, if unchecking, uncomplete.
-      const response = await processesApi.uncomplete(task.id);
-      setTaskIsComplete(false); 
-      // TODO: update UI for Taylor
-    } catch (err) {
-      console.error(err);
-    }
-
-    if (task.isLast) {
-      // TODO: Taylor
-      // handleUncompleteMilestone(); 
-    }
-    console.log("marking the task incomplete");
-  };
-
-
   return (
-    <>
-      <CustomDrawer anchor="right" open={open} onClose={toggle}>
-        <Stack
-          justifyContent="space-between"
-          direction="column"
-          sx={{ height: "100%" }}
-        >
-          <Card noBorder>
-            <Stack spacing={12}>
-              <Stack spacing={6}>
-                <Grid
-                  container
-                  justifyContent="space-between"
-                  alignItems="center"
-                >
-                  <Grid item>
-                    <Chip
-                      label={
-                        milestone
-                          ? "Milestone"
-                          : task.isDecision
-                          ? "Decision"
-                          : "Task"
-                      }
-                      size="small"
-                    />
-                  </Grid>
-                  <Grid item>
-                    <IconButton onClick={toggle}>
-                      <Icon type="close" />
-                    </IconButton>
-                  </Grid>
-                </Grid>
-
-                <Typography variant="bodyLarge" bold>
-                  {milestone ? milestone.title : task && task.title}
-                </Typography>
-                <Stack direction="row" spacing={4}>
-                  {task && (
-                    <Stack spacing={2}>
-                      <Typography variant="bodyMini" lightened bold>
-                        ASSIGNEE
-                      </Typography>
-                      <Avatar
-                        size="mini"
-                        // TODO: can we get the assignee information for each task in the process serializer
-                        // src={
-                        //   task.assignee.profileImage &&
-                        //   task.assignee.profileImage
-                        // }
-                      />
-                      {/* use assignee.src or equivalent, if none, show null */}
-                    </Stack>
-                  )}
-                  {milestone && milestone.status && (
-                    <Stack spacing={2}>
-                      <Typography variant="bodyMini" lightened bold>
-                        STATUS
-                      </Typography>
-                      <StatusChip
-                        status={milestone.status}
-                        size="small"
-                        withIcon
-                      />
-                    </Stack>
-                  )}
-                  {categories && (
-                    <Stack spacing={2}>
-                      <Typography variant="bodyMini" lightened bold>
-                        CATEGORY
-                      </Typography>
-                      <Stack direction="row" spacing={2}>
-                        {categories.map((m, i) => (
-                          <CategoryChip
-                            category={m}
-                            size="small"
-                            withIcon
-                            key={i}
-                          />
-                        ))}
-                      </Stack>
-                    </Stack>
-                  )}
-                  {milestone && milestone.effort && (
-                    <Stack spacing={2}>
-                      <Typography variant="bodyMini" lightened bold>
-                        EFFORT
-                      </Typography>
-                      <EffortChip
-                        size="small"
-                        effort={milestone.effort}
-                        withIcon
-                      />
-                    </Stack>
-                  )}
-                </Stack>
-              </Stack>
-              {task && task.resources && task.resources.data && (
-                <Stack spacing={2}>
-                  {task.resources.data.map((r, i) => (
-                    <Resource link={r.link} title={r.title} key={i} />
-                  ))}
-                </Stack>
-              )}
-              {about && (
-                <Stack spacing={4}>
-                  <Stack direction="row" spacing={4}>
-                    <Icon type="glasses" variant="primary" size="medium" />
-                    <Typography variant="bodyRegular" bold>
-                      About
-                    </Typography>
-                  </Stack>
-                  <Divider />
-                  <Typography>{about}</Typography>
-                </Stack>
-              )}
-              {task && assignee && task.isDecision && FakeDecisionOptions && (
-                <DecisionForm
-                  options={FakeDecisionOptions}
-                  isDecided={isDecided}
-                  decisionOption={decisionOption}
-                  handleDecisionOptionChange={handleDecisionOptionChange}
-                />
-              )}
-            </Stack>
-          </Card>
-          <Card noBorder>
+    <CustomDrawer anchor="right" open={open} onClose={toggle}>
+      <Stack
+        justifyContent="space-between"
+        direction="column"
+        sx={{ height: "100%" }}
+      >
+        <Card noBorder>
+          <Stack spacing={12}>
             <Stack spacing={6}>
-              <Divider />
-              <Grid container spacing={4}>
-                {milestone ? (
-                  <>
-                    <Grid item xs={6}>
-                      <Button full variant="secondary">
-                        <Typography>Ask your ops guide</Typography>
-                      </Button>
-                    </Grid>
-                    <Grid item xs={6}>
-                      <Link href={milestone.link}>
-                        <Button full>
-                          <Typography light bold>
-                            View {milestone && milestone.taskCount} tasks
-                          </Typography>
-                        </Button>
-                      </Link>
-                    </Grid>
-                  </>
-                ) : task && task.isDecision ? (
-                  assignee ? (
-                    isDecided ? (
-                      <Grid item xs={12}>
-                        <Button
-                          full
-                          variant="secondary"
-                          onClick={() => setIsDecided(false)}
-                        >
-                          <Typography>Change decision</Typography>
-                        </Button>
-                      </Grid>
-                    ) : (
-                      <Grid item xs={12}>
-                        <Button
-                          full
-                          disabled={!decisionOption}
-                          onClick={handleMakeDecision}
-                        >
-                          <Typography>Decide</Typography>
-                        </Button>
-                      </Grid>
-                    )
-                  ) : (
-                    <Grid item xs={12}>
-                      <Button full onClick={handleAssignSelf}>
-                        <Typography light bold>
-                          Assign yourself
-                        </Typography>
-                      </Button>
-                    </Grid>
-                  )
-                ) : assignee ? (
-                  taskIsComplete ? (
-                    <>
-                      <Grid item xs={6}>
-                        <Button
-                          full
-                          variant="secondary"
-                          onClick={handleAskOpsGuide}
-                        >
-                          <Typography light bold>
-                            Ask your ops guide
-                          </Typography>
-                        </Button>
-                      </Grid>
-                      <Grid item xs={6}>
-                        <Button
-                          full
-                          variant="danger"
-                          onClick={handleMarkTaskIncomplete}
-                        >
-                          <Typography bold>Mark incomplete</Typography>
-                        </Button>
-                      </Grid>
-                    </>
-                  ) : (
-                    <>
-                      <Grid item xs={6}>
-                        <Button
-                          full
-                          variant="text"
-                          onClick={handleUnassignSelf}
-                        >
-                          <Typography bold>Unassign yourself</Typography>
-                        </Button>
-                      </Grid>
-                      <Grid item xs={6}>
-                        <Button full onClick={handleCompleteTask}>
-                          <Typography light bold>
-                            Mark task complete
-                          </Typography>
-                        </Button>
-                      </Grid>
-                    </>
-                  )
-                ) : (
-                  <Grid item xs={12}>
-                    <Button full onClick={handleAssignSelf}>
-                      <Typography light bold>
-                        Assign yourself
-                      </Typography>
-                    </Button>
-                  </Grid>
-                )}
+              <Grid
+                container
+                justifyContent="space-between"
+                alignItems="center"
+              >
+                <Grid item>
+                  <Chip
+                    label={
+                      isDecision ? "Decision" : taskId ? "Task" : "Milestone"
+                    }
+                    size="small"
+                  />
+                </Grid>
+                <Grid item>
+                  <IconButton onClick={toggle}>
+                    <Icon type="close" />
+                  </IconButton>
+                </Grid>
               </Grid>
+
+              <Typography variant="bodyLarge" bold struck={isComplete}>
+                {title}
+              </Typography>
+              <Stack direction="row" spacing={4}>
+                {taskId && (
+                  <Stack spacing={2}>
+                    <Typography variant="bodyMini" lightened bold>
+                      ASSIGNEE
+                    </Typography>
+                    <Avatar
+                      size="mini"
+                      // TODO: can we get the assignee information for each task in the process serializer
+                      src={assignee && assignee.profileImage}
+                    />
+                  </Stack>
+                )}
+                {status && (
+                  <Stack spacing={2}>
+                    <Typography variant="bodyMini" lightened bold>
+                      STATUS
+                    </Typography>
+                    <StatusChip status={status} size="small" withIcon />
+                  </Stack>
+                )}
+                {categories && (
+                  <Stack spacing={2}>
+                    <Typography variant="bodyMini" lightened bold>
+                      CATEGORY
+                    </Typography>
+                    <Stack direction="row" spacing={2}>
+                      {categories.map((m, i) => (
+                        <CategoryChip
+                          category={m}
+                          size="small"
+                          withIcon
+                          key={i}
+                        />
+                      ))}
+                    </Stack>
+                  </Stack>
+                )}
+                {effort && (
+                  <Stack spacing={2}>
+                    <Typography variant="bodyMini" lightened bold>
+                      EFFORT
+                    </Typography>
+                    <EffortChip size="small" effort={effort} withIcon />
+                  </Stack>
+                )}
+              </Stack>
             </Stack>
-          </Card>
-        </Stack>
-      </CustomDrawer>
-      <TaskToast
-        open={assignToastOpen}
-        onClose={() => setAssignToastOpen(false)}
-        isAssignToast={true}
-        title={task && task.title}
-      />
-      <TaskToast
-        open={unassignToastOpen}
-        onClose={() => setUnassignToastOpen(false)}
-        isAssignToast={false}
-        title={task && task.title}
-      />
-    </>
+            {resources && resources.data && (
+              <Stack spacing={2}>
+                {resources.data.map((r, i) => (
+                  <Resource link={r.link} title={r.title} key={i} />
+                ))}
+              </Stack>
+            )}
+            {about && (
+              <Stack spacing={4}>
+                <Stack direction="row" spacing={4}>
+                  <Icon type="glasses" variant="primary" size="medium" />
+                  <Typography variant="bodyRegular" bold>
+                    About
+                  </Typography>
+                </Stack>
+                <Divider />
+                <Typography>{about}</Typography>
+              </Stack>
+            )}
+          </Stack>
+        </Card>
+        <Card noBorder>
+          <Stack spacing={6}>
+            <Divider />
+            {actions}
+          </Stack>
+        </Card>
+      </Stack>
+    </CustomDrawer>
   );
 };
 
 export default InfoDrawer;
-
-const TaskToast = ({ isAssignToast, open, onClose, title }) => {
-  return (
-    <Snackbar
-      open={open}
-      onClose={onClose}
-      autoHideDuration={6000}
-      anchorOrigin={{ vertical: "top", horizontal: "right" }}
-    >
-      <div>
-        <Card size="small" variant="primaryOutlined" sx={{ width: "320px" }}>
-          <Stack spacing={1}>
-            <Grid container alignItems="center" justifyContent="space-between">
-              <Grid item>
-                <Typography variant="bodySmall" lightened>
-                  TASK {isAssignToast ? "ASSIGNED" : "UNASSIGNED"}
-                </Typography>
-              </Grid>
-              <Grid item>
-                <Icon type="close" hoverable onClick={onClose} />
-              </Grid>
-            </Grid>
-            <Typography variant="bodyRegular" bold>
-              {title}
-            </Typography>
-            <Stack direction="row" spacing={3} alignItems="center">
-              <Avatar size="mini" />
-              {/* use assignee.src or equivalent, if none, show null */}
-              <Stack direction="row" spacing={1}>
-                <Typography variant="bodySmall">You</Typography>
-                <Typography variant="bodySmall" lightened>
-                  {isAssignToast ? "assigned" : "unassigned"}
-                </Typography>
-                <Typography variant="bodySmall">yourself</Typography>
-              </Stack>
-            </Stack>
-          </Stack>
-        </Card>
-      </div>
-    </Snackbar>
-  );
-};
-
-const DecisionForm = ({
-  options,
-  disabled,
-  isDecided,
-  decisionOption,
-  handleDecisionOptionChange,
-}) => {
-  const StyledDecisionCard = styled(Card)`
-    /* Disabled */
-    ${(props) =>
-      props.disabled &&
-      css`
-        opacity: 0.25;
-        pointer-events: none;
-      `}
-  `;
-
-  return (
-    <StyledDecisionCard
-      variant={isDecided ? "outlined" : "primaryOutlined"}
-      disabled={disabled}
-    >
-      <Stack spacing={6}>
-        <RadioGroup value={decisionOption} handleOptionsChange>
-          {options.map((o, i) => (
-            <FormControlLabel
-              key={i}
-              value={o.value}
-              control={<Radio disabled={isDecided} />}
-              label={o.label}
-              onChange={handleDecisionOptionChange}
-            />
-          ))}
-        </RadioGroup>
-      </Stack>
-    </StyledDecisionCard>
-  );
-};
-
-const FakeDecisionOptions = [
-  {
-    value: "wildflower group exemption",
-    label: "I will apply with the Wildflower Group Exemption",
-  },
-  {
-    value: "independently with irs",
-    label: "I will apply independently using Form 1023 with the IRS",
-  },
-];

--- a/components/Milestone.js
+++ b/components/Milestone.js
@@ -9,6 +9,7 @@ import {
   IconButton,
   Link,
   Avatar,
+  Button,
 } from "./ui";
 import CategoryChip from "./CategoryChip";
 import EffortChip from "./EffortChip";
@@ -94,20 +95,34 @@ const Milestone = ({
       </Link>
 
       <InfoDrawer
-        toggle={() => setInfoDrawerOpen(!infoDrawerOpen)}
-        milestone={{
-          title: title,
-          effort: effort,
-          status: status,
-          taskCount: stepCount,
-          link: link,
-        }}
-        categories={categories}
-        about="About the milestone"
         open={infoDrawerOpen}
+        toggle={() => setInfoDrawerOpen(!infoDrawerOpen)}
+        link={link}
+        title={title}
+        status={status}
+        effort={effort}
+        categories={categories}
+        about="..."
+        actions={<MilestoneDrawerActions stepCount={stepCount} link={link} />}
       />
     </>
   );
 };
 
 export default Milestone;
+
+const MilestoneDrawerActions = ({ stepCount, link }) => {
+  return (
+    <Grid container spacing={3}>
+      <Grid item xs={12}>
+        <Link href={link}>
+          <Button full>
+            <Typography light bold>
+              View {stepCount} tasks
+            </Typography>
+          </Button>
+        </Link>
+      </Grid>
+    </Grid>
+  );
+};

--- a/components/Task.js
+++ b/components/Task.js
@@ -1,6 +1,10 @@
 import { useState } from "react";
-import { FormControlLabel } from "@mui/material";
+import { FormControlLabel, RadioGroup } from "@mui/material";
 import { styled, css } from "@mui/material/styles";
+import processesApi from "../api/processes";
+import stepsApi from "../api/steps";
+import { useUserContext } from "@lib/useUserContext";
+
 import {
   Typography,
   Grid,
@@ -12,6 +16,9 @@ import {
   IconButton,
   Chip,
   Avatar,
+  Snackbar,
+  Card,
+  Radio,
 } from "./ui";
 import InfoDrawer from "./InfoDrawer";
 
@@ -47,12 +54,67 @@ const Task = ({
   link,
   handleCompleteMilestone,
   categories,
-  assignee,
+  taskAssignee,
   variant,
   resources,
 }) => {
   const [taskIsComplete, setTaskIsComplete] = useState(isComplete);
   const [infoDrawerOpen, setInfoDrawerOpen] = useState(false);
+  const [assignee, setAssignee] = useState(taskAssignee);
+  const [assignToastOpen, setAssignToastOpen] = useState(false);
+  const [unassignToastOpen, setUnassignToastOpen] = useState(false);
+  const [userIsUpdatingDecision, setUserIsUpdatingDecision] = useState(false);
+  const [isDecided, setIsDecided] = useState(false);
+  const { currentUser } = useUserContext();
+
+  async function handleCompleteTask() {
+    // api call, backend determiens state. needs spinner and error management.
+    try {
+      // if checking, complete, if unchecking, uncomplete.
+      const response = await processesApi.complete(taskId);
+      setTaskIsComplete(true);
+    } catch (err) {
+      console.error(err);
+    }
+
+    if (isLast) {
+      handleCompleteMilestone();
+      setInfoDrawerOpen(false);
+    }
+  }
+  async function handleUncompleteTask() {
+    // api call, backend determiens state. needs spinner and error management.
+    try {
+      // if checking, complete, if unchecking, uncomplete.
+      const response = await processesApi.uncomplete(taskId);
+      setTaskIsComplete(false);
+    } catch (err) {
+      console.error(err);
+    }
+  }
+  async function handleAssignSelf() {
+    try {
+      const response = await stepsApi.assign(taskId, currentUser.id);
+      setAssignee(currentUser);
+    } catch (err) {
+      console.error(err);
+    }
+    setAssignToastOpen(true);
+  }
+  async function handleUnassignSelf() {
+    try {
+      const response = await stepsApi.unassign(taskId);
+      setAssignee(null);
+    } catch (err) {
+      console.error(err);
+    }
+    setUnassignToastOpen(true);
+  }
+  const handleMakeDecision = () => {
+    //TODO: Api call to set decision
+    setUserIsUpdatingDecision(false);
+    setIsDecided(true);
+  };
 
   return (
     <>
@@ -72,12 +134,16 @@ const Task = ({
                 <>
                   <Icon
                     type="zap"
-                    variant={isComplete ? "primary" : "lightened"}
+                    variant={isDecided ? "primary" : "lightened"}
                   />
-                  <Chip label="Decision" size="small" />
+                  <Chip
+                    label={isDecided ? "Decided" : "Decision"}
+                    size="small"
+                    variant={isDecided && "primary"}
+                  />
                   <Typography
                     variant={variant === "small" ? "bodyRegular" : "bodyLarge"}
-                    struck={isComplete}
+                    struck={isDecided}
                     bold
                   >
                     {title}
@@ -86,13 +152,13 @@ const Task = ({
               ) : (
                 <Stack direction="row" spacing={4} alignItems="center">
                   <Icon
-                    type={isComplete ? "checkCircle" : "circle"}
-                    variant={isComplete ? "primary" : "lightened"}
+                    type={taskIsComplete ? "checkCircle" : "circle"}
+                    variant={taskIsComplete ? "primary" : "lightened"}
                   />
                   <Typography
                     variant={variant === "small" ? "bodyRegular" : "bodyLarge"}
                     bold
-                    struck={isComplete}
+                    struck={taskIsComplete}
                   >
                     {title}
                   </Typography>
@@ -111,33 +177,250 @@ const Task = ({
           )}
           <Grid item>
             <Stack direction="row" spacing={2} alignItems="center">
-              <Avatar
-                size="mini"
-                // src={assignee.profileImage && assignee.profileImage} TODO: get this to work!
-              />
+              <Avatar size="mini" src={assignee && assignee.profileImage} />
             </Stack>
           </Grid>
         </Grid>
       </StyledTask>
       <InfoDrawer
-        task={{
-          title: title,
-          id: taskId,
-          assignee: assignee,
-          resources: resources,
-          isComplete: isComplete,
-          isDecision: isDecision,
-          decisionOptions: decisionOptions,
-          isLast,
-        }}
-        categories={categories}
-        about="About the task"
         open={infoDrawerOpen}
         toggle={() => setInfoDrawerOpen(!infoDrawerOpen)}
-        // handleCompleteTask={handleCompleteTask}
+        assignee={assignee}
+        about="...."
+        taskId={taskId}
+        title={title}
+        resources={resources}
+        categories={categories}
+        isDecision={isDecision}
+        isComplete={taskIsComplete}
+        actions={
+          isDecision ? (
+            <DecisionDrawerActions
+              assignee={assignee}
+              isDecided={isDecided}
+              handleAssignSelf={handleAssignSelf}
+              handleUnassignSelf={handleUnassignSelf}
+              handleMakeDecision={handleMakeDecision}
+            />
+          ) : (
+            <TaskDrawerActions
+              assignee={assignee}
+              isComplete={isComplete}
+              handleAssignSelf={handleAssignSelf}
+              handleUnassignSelf={handleUnassignSelf}
+              handleCompleteTask={handleCompleteTask}
+              handleUncompleteTask={handleUncompleteTask}
+            />
+          )
+        }
+      />
+      <TaskToast
+        open={assignToastOpen}
+        onClose={() => setAssignToastOpen(false)}
+        isAssignToast={true}
+        title={title}
+        assignee={assignee}
+      />
+      <TaskToast
+        open={unassignToastOpen}
+        onClose={() => setUnassignToastOpen(false)}
+        isAssignToast={false}
+        title={title}
+        assignee={assignee}
       />
     </>
   );
 };
 
 export default Task;
+
+const DecisionDrawerActions = ({
+  assignee,
+  isDecided,
+  handleAssignSelf,
+  handleUnassignSelf,
+  handleMakeDecision,
+}) => {
+  const [decisionOption, setDecisionOption] = useState();
+  const handleDecisionOptionChange = (e) => {
+    setDecisionOption(e.target.value);
+  };
+  const StyledDecisionCard = styled(Card)`
+    /* Disabled */
+    ${(props) =>
+      props.disabled &&
+      css`
+        opacity: 0.5;
+        pointer-events: none;
+      `}
+  `;
+  return (
+    <Stack spacing={6}>
+      {assignee ? (
+        <Grid container>
+          <StyledDecisionCard
+            variant={isDecided ? "outlined" : "primaryOutlined"}
+            disabled={isDecided}
+          >
+            <Stack spacing={6}>
+              <RadioGroup value={decisionOption} handleOptionsChange>
+                {FakeDecisionOptions.map((o, i) => (
+                  <FormControlLabel
+                    key={i}
+                    value={o.value}
+                    control={<Radio disabled={isDecided} />}
+                    label={o.label}
+                    onChange={handleDecisionOptionChange}
+                  />
+                ))}
+              </RadioGroup>
+            </Stack>
+          </StyledDecisionCard>
+        </Grid>
+      ) : null}
+
+      <Grid container spacing={4}>
+        {assignee ? (
+          isDecided ? (
+            <Grid item xs={12}>
+              <Button
+                full
+                variant="secondary"
+                onClick={() => setIsDecided(false)}
+              >
+                <Typography>Change decision</Typography>
+              </Button>
+            </Grid>
+          ) : (
+            <>
+              <Grid item xs={6}>
+                <Button full variant="text" onClick={handleUnassignSelf}>
+                  <Typography bold>Unassign yourself</Typography>
+                </Button>
+              </Grid>
+              <Grid item xs={6}>
+                <Button
+                  full
+                  disabled={!decisionOption}
+                  onClick={handleMakeDecision}
+                >
+                  <Typography>Decide</Typography>
+                </Button>
+              </Grid>
+            </>
+          )
+        ) : (
+          <Grid item xs={12}>
+            <Button full onClick={handleAssignSelf}>
+              <Typography light bold>
+                Assign yourself
+              </Typography>
+            </Button>
+          </Grid>
+        )}
+      </Grid>
+    </Stack>
+  );
+};
+
+const TaskDrawerActions = ({
+  assignee,
+  isComplete,
+  handleAssignSelf,
+  handleUnassignSelf,
+  handleCompleteTask,
+  handleUncompleteTask,
+}) => {
+  return (
+    <>
+      <Grid container spacing={4}>
+        {assignee ? (
+          isComplete ? (
+            <>
+              <Grid item xs={12}>
+                <Button full variant="danger" onClick={handleUncompleteTask}>
+                  <Typography bold>Mark incomplete</Typography>
+                </Button>
+              </Grid>
+            </>
+          ) : (
+            <>
+              <Grid item xs={6}>
+                <Button full variant="text" onClick={handleUnassignSelf}>
+                  <Typography bold>Unassign yourself</Typography>
+                </Button>
+              </Grid>
+              <Grid item xs={6}>
+                <Button full onClick={handleCompleteTask}>
+                  <Typography light bold>
+                    Mark task complete
+                  </Typography>
+                </Button>
+              </Grid>
+            </>
+          )
+        ) : (
+          <Grid item xs={12}>
+            <Button full onClick={handleAssignSelf}>
+              <Typography light bold>
+                Assign yourself
+              </Typography>
+            </Button>
+          </Grid>
+        )}
+      </Grid>
+    </>
+  );
+};
+
+const TaskToast = ({ isAssignToast, open, onClose, title, assignee }) => {
+  return (
+    <Snackbar
+      open={open}
+      onClose={onClose}
+      autoHideDuration={4000}
+      anchorOrigin={{ vertical: "top", horizontal: "right" }}
+    >
+      <div>
+        <Card size="small" variant="primaryOutlined" sx={{ width: "320px" }}>
+          <Stack spacing={1}>
+            <Grid container alignItems="center" justifyContent="space-between">
+              <Grid item>
+                <Typography variant="bodySmall" lightened>
+                  TASK {isAssignToast ? "ASSIGNED" : "UNASSIGNED"}
+                </Typography>
+              </Grid>
+              <Grid item>
+                <Icon type="close" hoverable onClick={onClose} />
+              </Grid>
+            </Grid>
+            <Typography variant="bodyRegular" bold>
+              {title}
+            </Typography>
+            <Stack direction="row" spacing={3} alignItems="center">
+              <Avatar size="mini" src={assignee && assignee.profileImage} />
+              <Stack direction="row" spacing={1}>
+                <Typography variant="bodySmall">You</Typography>
+                <Typography variant="bodySmall" lightened>
+                  {isAssignToast ? "assigned" : "unassigned"}
+                </Typography>
+                <Typography variant="bodySmall">yourself</Typography>
+              </Stack>
+            </Stack>
+          </Stack>
+        </Card>
+      </div>
+    </Snackbar>
+  );
+};
+
+const FakeDecisionOptions = [
+  {
+    value: "wildflower group exemption",
+    label: "I will apply with the Wildflower Group Exemption",
+  },
+  {
+    value: "independently with irs",
+    label: "I will apply independently using Form 1023 with the IRS",
+  },
+];

--- a/components/ui/Avatar.js
+++ b/components/ui/Avatar.js
@@ -36,6 +36,15 @@ const CustomAvatar = styled(MaterialAvatar)`
       width: ${props.theme.util.buffer * 32}px;
       height: ${props.theme.util.buffer * 32}px;
     `}
+
+  /* hoverable */
+  ${(props) =>
+    props.hoverable &&
+    css`
+      &:hover {
+        cursor: pointer;
+      }
+    `}
 `;
 
 const Avatar = ({ ...props }) => {

--- a/components/ui/NavLink.js
+++ b/components/ui/NavLink.js
@@ -41,7 +41,11 @@ const NavLink = ({ to, icon, active, secondary, label }) => {
             </Grid>
           )}
           <Grid item>
-            <Typography highlight={active} bold={!secondary}>
+            <Typography
+              highlight={active}
+              bold={!secondary}
+              variant="bodyRegular"
+            >
               {label}
             </Typography>
           </Grid>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { theme } from "../styles/theme";
 import { ThemeProvider } from "@mui/material/styles";
 import CssBaseline from "@mui/material/CssBaseline";
-import { UserProvider, useUserContext } from "../lib/useUserContext";
+import { UserProvider } from "../lib/useUserContext";
 
 function MyApp({ Component, pageProps }) {
   return (

--- a/pages/ssj/[phase]/[milestone]/index.js
+++ b/pages/ssj/[phase]/[milestone]/index.js
@@ -5,8 +5,8 @@ import { useForm, Controller } from "react-hook-form";
 import { Container, Draggable } from "react-smooth-dnd";
 import { arrayMoveImmutable } from "array-move";
 import axios from "axios";
-import setAuthHeader from "../../../../lib/setAuthHeader"
-import baseUrl from "../../../../lib/utils/baseUrl"
+import setAuthHeader from "../../../../lib/setAuthHeader";
+import baseUrl from "../../../../lib/utils/baseUrl";
 
 import {
   Avatar,
@@ -30,14 +30,6 @@ import StatusChip from "../../../../components/StatusChip";
 import Milestone from "../../../../components/Milestone";
 
 const StyledMilestoneHeader = styled(Stack)`
-  /* downplayed */
-  ${(props) =>
-    props.downplayed &&
-    css`
-      opacity: 0.5;
-    `}
-`;
-const StyledMilestoneTasks = styled(Card)`
   /* downplayed */
   ${(props) =>
     props.downplayed &&
@@ -72,7 +64,7 @@ const MilestonePage = ({
   const router = useRouter();
   const { phase } = router.query;
 
-  console.log("Tasks", MilestoneTasks);
+  // console.log("Tasks", MilestoneTasks);
   // console.log("MilestoneAttributes", MilestoneAttributes);
   // console.log("Milestone Relationships", MilestoneRelationships);
 
@@ -204,61 +196,59 @@ const MilestonePage = ({
           </StyledMilestoneHeader>
         </Stack>
 
-        <StyledMilestoneTasks downplayed={isUpNext}>
-          <Stack>
-            <Stack direction="row" spacing={3} alignItems="center">
-              <Icon type="checkDouble" variant="primary" size="large" />
-              <Typography variant="h4" bold>
-                Tasks
-              </Typography>
-            </Stack>
-            {userIsEditing ? (
-              <>
-                <NewTaskInput />
-                <EditableTaskList tasks={FakeMilestoneTasks} />
-              </>
-            ) : MilestoneTasks ? (
-              MilestoneTasks.map((t, i) => (
-                <Task
-                  taskId={t.id}
-                  link={`/ssj/${phase}/${MilestoneId}/${t.id}`}
-                  title={t.attributes.title}
-                  key={i}
-                  isDecision={t.attributes.kind === "Decision"}
-                  decisionOptions={t.attributes.decisionOptions}
-                  isLast={i + 1 === FakeMilestoneTasks.length}
-                  isComplete={t.attributes.completed}
-                  handleCompleteMilestone={handleCompleteMilestone}
-                  categories={MilestoneAttributes.categories}
-                  assignee={t.relationships.assignee.data}
-                  resources={t.relationships.documents.data}
-                />
-              ))
-            ) : (
-              <Card hoverable elevated size="small">
-                <Grid
-                  container
-                  justifyContent="space-between"
-                  alignItems="center"
-                >
-                  <Grid item>
-                    <Stack>
-                      <Typography variant="bodyRegular" bold>
-                        Looks like there are no tasks for this milestone.
-                      </Typography>
-                      <Typography variant="bodySmall" lightened>
-                        Add a task to do in order to complete this milestone.
-                      </Typography>
-                    </Stack>
-                  </Grid>
-                  <Grid item>
-                    <Icon type="plus" variant="primary" />
-                  </Grid>
-                </Grid>
-              </Card>
-            )}
+        <Stack>
+          <Stack direction="row" spacing={3} alignItems="center">
+            <Icon type="checkDouble" variant="primary" size="large" />
+            <Typography variant="h4" bold>
+              Tasks
+            </Typography>
           </Stack>
-        </StyledMilestoneTasks>
+          {userIsEditing ? (
+            <>
+              <NewTaskInput />
+              <EditableTaskList tasks={FakeMilestoneTasks} />
+            </>
+          ) : MilestoneTasks ? (
+            MilestoneTasks.map((t, i) => (
+              <Task
+                taskId={t.id}
+                link={`/ssj/${phase}/${MilestoneId}/${t.id}`}
+                title={t.attributes.title}
+                key={i}
+                isDecision={t.attributes.kind === "Decision"}
+                decisionOptions={t.attributes.decisionOptions}
+                isLast={i + 1 === MilestoneTasks.length}
+                isComplete={t.attributes.completed}
+                handleCompleteMilestone={handleCompleteMilestone}
+                categories={MilestoneAttributes.categories}
+                taskAssignee={t.relationships.assignee.data}
+                resources={t.relationships.documents.data}
+              />
+            ))
+          ) : (
+            <Card hoverable elevated size="small">
+              <Grid
+                container
+                justifyContent="space-between"
+                alignItems="center"
+              >
+                <Grid item>
+                  <Stack>
+                    <Typography variant="bodyRegular" bold>
+                      Looks like there are no tasks for this milestone.
+                    </Typography>
+                    <Typography variant="bodySmall" lightened>
+                      Add a task to do in order to complete this milestone.
+                    </Typography>
+                  </Stack>
+                </Grid>
+                <Grid item>
+                  <Icon type="plus" variant="primary" />
+                </Grid>
+              </Grid>
+            </Card>
+          )}
+        </Stack>
 
         {userIsEditing ? (
           <Grid container alignItems="center" justifyContent="space-between">
@@ -300,7 +290,7 @@ const MilestonePage = ({
                 </Typography>
               </Stack>
               <Typography variant="h2" bold>
-                Name Your School
+                {MilestoneTitle}
               </Typography>
               <Typography variant="bodyLarge" lightened center>
                 You're making great progress!
@@ -413,7 +403,7 @@ export async function getServerSideProps({ query, req, res }) {
   const apiRoute = `${baseUrl}/v1/workflow/processes/${MilestoneId}`;
   setAuthHeader({ req, res });
 
-  const response = await axios.get(apiRoute)
+  const response = await axios.get(apiRoute);
   const data = await response.data;
 
   const Workflow = data.included.filter((i) => i.type === "workflow");

--- a/pages/ssj/[phase]/index.js
+++ b/pages/ssj/[phase]/index.js
@@ -2,9 +2,9 @@ import { useRouter } from "next/router";
 import { useState } from "react";
 import { RadioGroup, FormControlLabel } from "@mui/material";
 import { useForm, Controller } from "react-hook-form";
-import setAuthHeader from "../../../lib/setAuthHeader"
+import setAuthHeader from "../../../lib/setAuthHeader";
 import axios from "axios";
-import baseUrl from "../../../lib/utils/baseUrl"
+import baseUrl from "../../../lib/utils/baseUrl";
 
 import {
   PageContainer,
@@ -25,10 +25,7 @@ import {
 import Milestone from "../../../components/Milestone";
 
 const PhasePage = ({
-  FakeMilestonesToDo,
-  FakeMilestonesUpNext,
   FakeMilestonesToConsider,
-  FakeMilestonesDone,
   data,
   milestonesToDo,
   milestonesUpNext,
@@ -41,7 +38,7 @@ const PhasePage = ({
   const router = useRouter();
   const { phase } = router.query;
 
-  console.log({ data });
+  // console.log({ data });
 
   return (
     <>
@@ -60,7 +57,7 @@ const PhasePage = ({
                     justifyContent="space-between"
                     alignItems="center"
                   >
-                    <Grid item>
+                    <Grid item ml={3}>
                       <Stack direction="row" spacing={6}>
                         <Icon type="circle" variant="primary" />
                         <Typography variant="bodyLarge" bold>
@@ -70,15 +67,6 @@ const PhasePage = ({
                           {milestonesToDo.length}
                         </Typography>
                       </Stack>
-                    </Grid>
-                    <Grid item>
-                      <IconButton
-                        onClick={() =>
-                          setAddMilestoneModalOpen(!addMilestoneModalOpen)
-                        }
-                      >
-                        <Icon type="plus" variant="lightened" />
-                      </IconButton>
                     </Grid>
                   </Grid>
 
@@ -106,7 +94,7 @@ const PhasePage = ({
                     justifyContent="space-between"
                     alignItems="center"
                   >
-                    <Grid item>
+                    <Grid item ml={3}>
                       <Stack direction="row" spacing={6}>
                         <Icon type="rightArrowCircle" variant="lightened" />
                         <Typography variant="bodyLarge" bold>
@@ -116,9 +104,6 @@ const PhasePage = ({
                           {milestonesUpNext.length}
                         </Typography>
                       </Stack>
-                    </Grid>
-                    <Grid item>
-                      <Icon type="plus" variant="lightened" />
                     </Grid>
                   </Grid>
                   <Stack spacing={3}>
@@ -144,7 +129,7 @@ const PhasePage = ({
                     justifyContent="space-between"
                     alignItems="center"
                   >
-                    <Grid item>
+                    <Grid item ml={3}>
                       <Stack direction="row" spacing={6}>
                         <Icon type="checkCircle" variant="success" />
                         <Typography variant="bodyLarge" bold>
@@ -154,9 +139,6 @@ const PhasePage = ({
                           {milestonesDone.length}
                         </Typography>
                       </Stack>
-                    </Grid>
-                    <Grid item>
-                      <Icon type="plus" variant="lightened" />
                     </Grid>
                   </Grid>
                   <Stack spacing={3}>
@@ -373,15 +355,15 @@ const AddMilestoneModal = ({ toggle, title, open }) => {
   );
 };
 
-export async function getServerSideProps({params, req, res}) {
+export async function getServerSideProps({ params, req, res }) {
   // const userId = query.userId;
   // const ssjId = query.ssjId;
 
   const { phase } = params;
-  const workflowId = "b9fb-d65c"
+  const workflowId = "b9fb-d65c";
   // const workflowId = "9afe-6e28"
   const apiRoute = `${baseUrl}/v1/workflow/workflows/${workflowId}/processes?phase=${phase}`;
-  setAuthHeader({req, res});
+  setAuthHeader({ req, res });
 
   const response = await axios.get(apiRoute);
   const data = await response.data;


### PR DESCRIPTION
- Light refactor of `InfoDrawer` to accept `actions` rather than doing confusing logic in the component to decide what actions a user can take
- Move all the state previously in `InfoDrawer` into the `Task` component so that the state can be shared across the entire `[milestone]` page
- Component and state/handler scoping