### PR TITLE
[DO NOT MERGE] draft to show an async function in useUserContext

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useMediaQuery } from "react-responsive";
 import { styled, css } from "@mui/material/styles";
 import { AppBar, IconButton, ListItem } from "@mui/material";
@@ -42,7 +42,6 @@ const CustomAppBar = styled(AppBar)`
 
 const Header = ({ toggleNavOpen }) => {
   const isSm = useMediaQuery({ maxDeviceWidth: theme.breakpoints.values.sm });
-
   const { currentUser, isLoggedIn } = useUserContext();
 
   const logo = "/assets/images/wildflower-logo.png";
@@ -89,10 +88,10 @@ const Header = ({ toggleNavOpen }) => {
             <AvatarMenu
               showNetwork={showNetwork}
               myProfileLink={
-                showNetwork ? `/network/people/${currentUser.id}` : null
+                showNetwork ? `/network/people/${currentUser?.id}` : null
               }
               avatarSrc={currentUser?.attributes?.imageUrl}
-              userName={`${currentUser.attributes.firstName} ${currentUser.attributes.lastName}`}
+              userName={`${currentUser?.attributes.firstName} ${currentUser?.attributes.lastName}`}
             />
           </Grid>
         ) : null}

--- a/lib/useUserContext.js
+++ b/lib/useUserContext.js
@@ -21,61 +21,63 @@ export function UserProvider({ children }) {
   const token = getCookie("auth");
   const [currentUser, setCurrentUser] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [isLoggedIn, setIsLoggedIn] = useState(false); // Initialize isLoggedIn state
 
   const router = useRouter();
   useEffect(() => {
-    console.log("checking for user");
-    if (token && !pagesWithNoUserRequired.includes(router.asPath)) {
-      let ignore = false;
-      setCurrentUser(null);
+    async function fetchData() {
+      if (!token || pagesWithNoUserRequired.includes(router.asPath)) {
+        setLoading(false);
 
-      // setting global header for all axios requests on the CLIENT SIDE ONLY
-      // token will not be leaked to another user's requests
-      axios.defaults.headers.common["Authorization"] = token;
-      const config = { headers: { Authorization: token } };
-      const decoded = jwt_decode(token);
+        return;
+      }
 
-      usersApi
-        .show(decoded.sub, config)
-        .then((result) => {
-          const type = result.data?.data?.type;
-          const userAttributes = result.data?.data?.attributes;
-          const personId = result.data?.data?.relationships?.person?.data?.id;
-          const personAddress = result.data?.included?.find((a) => {
-            return a.type === "address";
-          })?.attributes;
-          if (!!userAttributes && !ignore) {
-            const user = {
-              id: personId,
-              type: type,
-              attributes: userAttributes,
-              personAddress: personAddress,
-            };
-            setCurrentUser(user);
-          }
-          console.log("highlight.io identifer", userAttributes.id);
+      try {
+        axios.defaults.headers.common["Authorization"] = token;
+
+        const config = { headers: { Authorization: token } };
+        const decoded = jwt_decode(token);
+        const response = await usersApi.show(decoded.sub, config);
+
+        const type = response.data?.data?.type;
+        const userAttributes = response.data?.data?.attributes;
+        const personId = response.data?.data?.relationships?.person?.data?.id;
+        const personAddress = response.data?.included?.find(
+          (a) => a.type === "address"
+        )?.attributes;
+
+        if (!!userAttributes) {
+          const user = {
+            id: personId,
+            type: type,
+            attributes: userAttributes,
+            personAddress: personAddress,
+          };
+          setCurrentUser(user);
+          setIsLoggedIn(true);
           H.identify(userAttributes.email, {
-            userId: result.data?.data?.id,
+            userId: response.data?.data?.id,
             firstName: userAttributes.firstName,
             lastName: userAttributes.lastName,
           });
-        })
-        .catch((error) => {
-          // TODO: catch error. Should not
-          console.log(error);
-          console.error(error);
-          clearLoggedInState({});
-
-          router.push("/login");
-        });
-      return () => {
-        ignore = true;
-      };
-    } else {
+        }
+      } catch (error) {
+        console.error(error);
+        clearLoggedInState({});
+        setCurrentUser(null);
+        setIsLoggedIn(false); // Set isLoggedIn to false when clearing state
+        router.push("/login");
+      } finally {
+        setLoading(false);
+      }
     }
-  }, [token]);
 
-  const isLoggedIn = !!(token && currentUser);
+    fetchData();
+  }, [token, router.asPath]);
+
+  if (loading) {
+    return <p>Loading...</p>;
+  }
 
   return (
     <UserContext.Provider value={{ currentUser, setCurrentUser, isLoggedIn }}>

--- a/lib/utils/useAuth.js
+++ b/lib/utils/useAuth.js
@@ -6,6 +6,8 @@ const useAuth = (redirectUrl) => {
   const router = useRouter();
   const { isLoggedIn } = useUserContext(); // Assuming you have a context for user authentication
 
+  console.log({ isLoggedIn });
+
   useEffect(() => {
     // Check if the user is not logged in and should be redirected
     if (!isLoggedIn && redirectUrl && router.asPath !== redirectUrl) {


### PR DESCRIPTION
**Context**
- Previously on page load `isLoggedIn` from `useUserContext` would momentarily return `false`, only to re-run and then load `true`. This would not have been an issue, except I have been trying to implement redirects for certain pages based on whether `isLoggedIn` is true or not (like in the onboarding flow). The momentary `false` returned from `useUserContext` triggered a redirect, when in reality, the user _was_ logged in and should have remained on the page.

**This PR**
- Rewrites the `useUserContext` function to be async, waiting for the result, before setting anything. This successfully eliminated the momentary `false` on `isLoggedIn`

**Continued problems**
- Now, when the user clicks "Log out" from the header menu, the `isLoggedIn` state stays `true` when redirecting to the `/logged-out` route. 

This is confusing because:

- The new `useUserContext` useEffect function should re-run whenever the `token` or `router.asPath` changes... which it does! 