### PR TITLE
[Fix] 401 redirection due to error in API calls

### DIFF
--- a/api/auth.js
+++ b/api/auth.js
@@ -1,5 +1,10 @@
 import axios from "axios";
-import { setCookie } from "cookies-next";
+import { setCookie, getCookie } from "cookies-next";
+
+function getAuthHeader() {
+  const token = getCookie("auth");
+  return { headers: { Authorization: token } };
+}
 
 const api = axios.create({
   baseURL: `${process.env.API_URL}`,
@@ -47,9 +52,14 @@ async function tokenAuth(token) {
 }
 
 async function loginEmailLink(email) {
-  const response = await api.post(`/users/email_login`, {
-    email: email,
-  });
+  const config = getAuthHeader();
+  const response = await api.post(
+    `/users/email_login`,
+    {
+      email: email,
+    },
+    config
+  );
   const result = await response.json;
   return result;
 }

--- a/api/base.js
+++ b/api/base.js
@@ -161,11 +161,11 @@ async function handleErrors(promise) {
       console.log(error.response.data);
       console.log(error.response.status);
       console.log(error.response.headers);
-      // if (error.response.status === 401) {
-      //   clearLoggedInState({});
-      //   setCurrentUser(null);
-      //   Router.push("/login");
-      // }
+      if (error.response.status === 401) {
+        clearLoggedInState({});
+        setCurrentUser(null);
+        Router.push("/login");
+      }
     } else if (error.request) {
       console.log(error.request);
     } else {

--- a/api/base.js
+++ b/api/base.js
@@ -33,12 +33,7 @@ function register(path, options) {
       "Content-Type": "application/json",
     },
   };
-  if (token) {
-    // console.log("token from cookies", jwt_decode(token).sub)
-    config.headers["Authorization"] = token;
-  } else if (axios.defaults.headers.common["Authorization"]) {
-    // console.log("token set from axios global", jwt_decode(axios.defaults.headers.common['Authorization']).sub);
-  }
+
   const client = axios.create(config);
 
   client.interceptors.response.use(

--- a/api/people.js
+++ b/api/people.js
@@ -42,9 +42,11 @@ async function update(personId, personParams) {
 // filter example: {{ops_guide: true, rgl: true}}
 // TODO update with SWR hook
 async function index(filter) {
+  const config = getAuthHeader();
+  config.params = filter;
   let response;
   try {
-    response = await peopleApi.get(`/`, { params: filter });
+    response = await peopleApi.get(`/`, config);
   } catch (error) {
     return Promise.reject(error);
   }

--- a/api/people.js
+++ b/api/people.js
@@ -16,8 +16,10 @@ function show(personId, params = {}) {
 export const showPerson = {
   key: (personId, params) => `/v1/people/${personId}`,
   fetcher: (personId, params) => {
+    const config = getAuthHeader();
+    config.params = params;
     return peopleApi
-      .get(`/${personId}`, { params: params })
+      .get(`/${personId}`, config)
       .then((data) => {
         return data;
       })

--- a/api/people.js
+++ b/api/people.js
@@ -1,7 +1,14 @@
+import { getCookie } from "cookies-next";
 import wildflowerApi from "@api/base";
 
 const peopleApi = wildflowerApi.register(`/v1/people`);
 
+function getAuthHeader() {
+  const token = getCookie("auth");
+  return { headers: { Authorization: token } };
+}
+
+// DEPRECATED for showPerson
 function show(personId, params = {}) {
   return peopleApi.get(`/${personId}`, { params: params });
 }
@@ -23,7 +30,8 @@ export const showPerson = {
 async function update(personId, personParams) {
   let response;
   try {
-    response = await peopleApi.put(`/${personId}`, personParams);
+    const config = getAuthHeader();
+    response = await peopleApi.put(`/${personId}`, personParams, config);
   } catch (error) {
     return Promise.reject(error);
   }
@@ -32,6 +40,7 @@ async function update(personId, personParams) {
 }
 
 // filter example: {{ops_guide: true, rgl: true}}
+// TODO update with SWR hook
 async function index(filter) {
   let response;
   try {

--- a/api/schools.js
+++ b/api/schools.js
@@ -1,11 +1,19 @@
+import { getCookie } from "cookies-next";
 import wildflowerApi from "@api/base";
 
 const schoolsApi = wildflowerApi.register("/v1/schools", {});
 
+function getAuthHeader() {
+  const token = getCookie("auth");
+  return { headers: { Authorization: token } };
+}
+
+// TODO update to SWR hook
 async function index() {
   return schoolsApi.get();
 }
 
+// DEPRECATED for showSchool
 async function show(id, params = {}) {
   return schoolsApi.get(`/${id}`, params);
 }
@@ -13,8 +21,10 @@ async function show(id, params = {}) {
 export const showSchool = {
   key: (schoolId, params) => `/v1/schools/${schoolId}`,
   fetcher: (schoolId, params) => {
+    const config = getAuthHeader();
+    config.params = params;
     return schoolsApi
-      .get(`/${schoolId}`, { params: params })
+      .get(`/${schoolId}`, config)
       .then((data) => {
         return data;
       })
@@ -25,7 +35,8 @@ export const showSchool = {
 };
 
 async function update(id, params = {}) {
-  return schoolsApi.put(`/${id}`, params);
+  const config = getAuthHeader();
+  return schoolsApi.put(`/${id}`, params, config);
 }
 
 export default { index, show, update };

--- a/api/users.js
+++ b/api/users.js
@@ -21,6 +21,7 @@ const api = axios.create({
   },
 });
 
+// DEPRECATED for showUser
 async function show(id, config) {
   let response;
   try {
@@ -34,8 +35,9 @@ async function show(id, config) {
 export const showUser = {
   key: (userId) => `/v1/users/${userId}`,
   fetcher: (userId) => {
+    const config = getAuthHeader();
     return api
-      .get(`/${userId}`, getAuthHeader())
+      .get(`/${userId}`, config)
       .then((data) => {
         return data;
       })

--- a/api/workflow/processes.js
+++ b/api/workflow/processes.js
@@ -10,6 +10,7 @@ function getAuthHeader() {
 const workflowsApi = wildflowerApi.register("/v1/workflow", {});
 
 // show me all milestones for a phase
+// DEPRECATED for showMilestones
 async function index({ workflowId, params, config = {} }) {
   let url = `/workflows/${workflowId}/processes`;
   if (params !== undefined) {
@@ -48,8 +49,9 @@ export const showMilestones = {
     return url;
   },
   fetcher: (workflowId, params) => {
+    const config = getAuthHeader();
     return workflowsApi
-      .get(showMilestones.key(workflowId, params), getAuthHeader())
+      .get(showMilestones.key(workflowId, params), config)
       .then((res) => {
         return res;
       })
@@ -60,6 +62,7 @@ export const showMilestones = {
 };
 
 // look at an individual process/milestone
+// DEPRECATED for showMilestone
 async function show(id, config = {}) {
   let response;
   try {
@@ -84,8 +87,9 @@ async function show(id, config = {}) {
 export const showMilestone = {
   key: (id) => `/processes/${id}`,
   fetcher: (id) => {
+    const config = getAuthHeader();
     return workflowsApi
-      .get(showMilestone.key(id), getAuthHeader())
+      .get(showMilestone.key(id), config)
       .then((response) => {
         const included = response.data.included;
         wildflowerApi.loadAllRelationshipsFromIncluded(response.data);

--- a/api/workflow/steps.js
+++ b/api/workflow/steps.js
@@ -121,7 +121,7 @@ async function assign(taskId) {
   console.log("config------------------------", config);
   let response;
   try {
-    response = await workflowsApi.put(`/steps/${taskId}/assign`, config);
+    response = await workflowsApi.put(`/steps/${taskId}/assign`, {}, config);
   } catch (error) {
     return Promise.reject(error);
   }
@@ -134,7 +134,7 @@ async function unassign(taskId) {
   const config = getAuthHeader();
   let response;
   try {
-    response = await workflowsApi.put(`/steps/${taskId}/unassign`, config);
+    response = await workflowsApi.put(`/steps/${taskId}/unassign`, {}, config);
   } catch (error) {
     return Promise.reject(error);
   }
@@ -148,7 +148,7 @@ async function complete(taskId) {
   const config = getAuthHeader();
   let response;
   try {
-    response = await workflowsApi.put(`/steps/${taskId}/complete`, config);
+    response = await workflowsApi.put(`/steps/${taskId}/complete`, {}, config);
   } catch (error) {
     return Promise.reject(error);
   }
@@ -161,7 +161,11 @@ async function uncomplete(taskId) {
   const config = getAuthHeader();
   let response;
   try {
-    response = await workflowsApi.put(`/steps/${taskId}/uncomplete`, config);
+    response = await workflowsApi.put(
+      `/steps/${taskId}/uncomplete`,
+      {},
+      config
+    );
   } catch (error) {
     return Promise.reject(error);
   }

--- a/api/workflow/steps.js
+++ b/api/workflow/steps.js
@@ -118,7 +118,6 @@ async function create(processId, title) {
 
 async function assign(taskId) {
   const config = getAuthHeader();
-  console.log("config------------------------", config);
   let response;
   try {
     response = await workflowsApi.put(`/steps/${taskId}/assign`, {}, config);
@@ -192,6 +191,7 @@ async function selectOption(taskId, optionId) {
   return response;
 }
 
+//TODO turn this into an SWR hook
 async function show({ milestoneId, taskId, config = {} }) {
   let response;
   try {

--- a/api/workflow/steps.js
+++ b/api/workflow/steps.js
@@ -57,6 +57,7 @@ function augmentStep(step, included) {
 }
 
 // Grab assigned steps, given a workflow id
+//DEPRECATED for showAssigned
 async function assigned(workflowId, config = {}) {
   let response;
   try {
@@ -104,16 +105,23 @@ export const showAssigned = {
 
 // creates a custom task (TODO: not finished)
 async function create(processId, title) {
-  return await workflowsApi.post(`/processes/${processId}/steps`, {
-    title: title,
-  });
+  const config = getAuthHeader();
+  return await workflowsApi.post(
+    `/processes/${processId}/steps`,
+    {
+      title: title,
+    },
+    config
+  );
   // if response good, great.  else.  error out?
 }
 
 async function assign(taskId) {
+  const config = getAuthHeader();
+  console.log("config------------------------", config);
   let response;
   try {
-    response = await workflowsApi.put(`/steps/${taskId}/assign`);
+    response = await workflowsApi.put(`/steps/${taskId}/assign`, config);
   } catch (error) {
     return Promise.reject(error);
   }
@@ -123,9 +131,10 @@ async function assign(taskId) {
 }
 
 async function unassign(taskId) {
+  const config = getAuthHeader();
   let response;
   try {
-    response = await workflowsApi.put(`/steps/${taskId}/unassign`);
+    response = await workflowsApi.put(`/steps/${taskId}/unassign`, config);
   } catch (error) {
     return Promise.reject(error);
   }
@@ -136,9 +145,10 @@ async function unassign(taskId) {
 
 // if response good, great.  else.  error out?
 async function complete(taskId) {
+  const config = getAuthHeader();
   let response;
   try {
-    response = await workflowsApi.put(`/steps/${taskId}/complete`);
+    response = await workflowsApi.put(`/steps/${taskId}/complete`, config);
   } catch (error) {
     return Promise.reject(error);
   }
@@ -148,9 +158,10 @@ async function complete(taskId) {
 
 // TODO: do something w/ the response if it's not 200
 async function uncomplete(taskId) {
+  const config = getAuthHeader();
   let response;
   try {
-    response = await workflowsApi.put(`/steps/${taskId}/uncomplete`);
+    response = await workflowsApi.put(`/steps/${taskId}/uncomplete`, config);
   } catch (error) {
     return Promise.reject(error);
   }
@@ -159,11 +170,16 @@ async function uncomplete(taskId) {
 }
 
 async function selectOption(taskId, optionId) {
+  const config = getAuthHeader();
   let response;
   try {
-    response = await workflowsApi.put(`/steps/${taskId}/select_option`, {
-      selected_option_id: optionId,
-    });
+    response = await workflowsApi.put(
+      `/steps/${taskId}/select_option`,
+      {
+        selected_option_id: optionId,
+      },
+      config
+    );
   } catch (error) {
     return Promise.reject(error);
   }

--- a/pages/ssj/[workflow]/[phase]/[milestone]/index.js
+++ b/pages/ssj/[workflow]/[phase]/[milestone]/index.js
@@ -2,14 +2,14 @@ import { useRouter } from "next/router";
 import { useState } from "react";
 import { styled, css } from "@mui/material/styles";
 import { useForm, Controller } from "react-hook-form";
-import { Container, Draggable } from "react-smooth-dnd";
+// import { Container, Draggable } from "react-smooth-dnd";
 import { arrayMoveImmutable } from "array-move";
 import getAuthHeader from "@lib/getAuthHeader";
 import processesApi from "@api/workflow/processes";
 import { clearLoggedInState, redirectLoginProps } from "@lib/handleLogout";
 import Skeleton from "@mui/material/Skeleton";
 
-import useAuth from "@lib/utils/useAuth";
+// import useAuth from "@lib/utils/useAuth";
 import {
   Avatar,
   Button,
@@ -56,11 +56,13 @@ const MilestonePage = ({ FakeMilestoneTasks }) => {
   var milestonePrerequisites =
     milestone?.relationships?.prerequisiteProcesses?.data;
 
-  const sortedMilestoneTasks = milestone?.relationships?.steps?.data.sort(
-    (a, b) => (a.attributes.position > b.attributes.position ? 1 : -1)
+  const milestoneRelationships = milestone?.relationships?.steps?.data;
+
+  const sortedMilestoneTasks = milestoneRelationships?.sort((a, b) =>
+    a.attributes.position > b.attributes.position ? 1 : -1
   );
 
-  useAuth("/login");
+  // useAuth("/login");
 
   return (
     <PageContainer>
@@ -214,8 +216,9 @@ const MilestonePage = ({ FakeMilestoneTasks }) => {
             </Stack>
             {userIsEditing ? (
               <>
-                <NewTaskInput />
-                <EditableTaskList tasks={FakeMilestoneTasks} />
+                <Typography>Coming Soon</Typography>
+                {/* <NewTaskInput />
+                <EditableTaskList tasks={FakeMilestoneTasks} /> */}
               </>
             ) : sortedMilestoneTasks ? (
               sortedMilestoneTasks.map((t, i) => (
@@ -378,29 +381,29 @@ const EditableTaskItem = ({ title, isDraggable }) => {
     </Grid>
   );
 };
-const EditableTaskList = ({ tasks }) => {
-  const [taskList, setTaskList] = useState(tasks);
+// const EditableTaskList = ({ tasks }) => {
+//   const [taskList, setTaskList] = useState(tasks);
 
-  const onDrop = ({ removedIndex, addedIndex }) => {
-    // console.log({ removedIndex, addedIndex });
-    setTaskList((items) => arrayMoveImmutable(items, removedIndex, addedIndex));
-  };
-  return (
-    <Container dragHandleSelector=".drag-handle" lockAxis="y" onDrop={onDrop}>
-      <Stack spacing={3}>
-        {taskList &&
-          taskList.map((t, i) => (
-            <Draggable key={i}>
-              <EditableTaskItem
-                title={t.title}
-                isDraggable={!t.isSensibleDefault}
-              />
-            </Draggable>
-          ))}
-      </Stack>
-    </Container>
-  );
-};
+//   const onDrop = ({ removedIndex, addedIndex }) => {
+//     // console.log({ removedIndex, addedIndex });
+//     setTaskList((items) => arrayMoveImmutable(items, removedIndex, addedIndex));
+//   };
+//   return (
+//     <Container dragHandleSelector=".drag-handle" lockAxis="y" onDrop={onDrop}>
+//       <Stack spacing={3}>
+//         {taskList &&
+//           taskList.map((t, i) => (
+//             <Draggable key={i}>
+//               <EditableTaskItem
+//                 title={t.title}
+//                 isDraggable={!t.isSensibleDefault}
+//               />
+//             </Draggable>
+//           ))}
+//       </Stack>
+//     </Container>
+//   );
+// };
 
 export async function getServerSideProps() {
   const FakeMilestoneTasks = [

--- a/pages/ssj/[workflow]/[phase]/[milestone]/index.js
+++ b/pages/ssj/[workflow]/[phase]/[milestone]/index.js
@@ -9,7 +9,7 @@ import processesApi from "@api/workflow/processes";
 import { clearLoggedInState, redirectLoginProps } from "@lib/handleLogout";
 import Skeleton from "@mui/material/Skeleton";
 
-// import useAuth from "@lib/utils/useAuth";
+import useAuth from "@lib/utils/useAuth";
 import {
   Avatar,
   Button,
@@ -62,7 +62,7 @@ const MilestonePage = ({ FakeMilestoneTasks }) => {
     a.attributes.position > b.attributes.position ? 1 : -1
   );
 
-  // useAuth("/login");
+  useAuth("/login");
 
   return (
     <PageContainer>

--- a/pages/ssj/[workflow]/index.js
+++ b/pages/ssj/[workflow]/index.js
@@ -12,7 +12,7 @@ import ssjApi from "@api/ssj/ssj";
 import teamsApi from "@api/ssj/teams";
 import processesApi from "@api/workflow/processes";
 import { useUserContext } from "@lib/useUserContext";
-// import useAuth from "@lib/utils/useAuth";
+import useAuth from "@lib/utils/useAuth";
 import { clearLoggedInState, redirectLoginProps } from "@lib/handleLogout";
 import Milestone from "../../../components/Milestone";
 import Task from "../../../components/Task";
@@ -116,7 +116,7 @@ const SSJ = () => {
   const regionalGrowthLead =
     currentUser?.attributes?.ssj?.regionalGrowthLead?.data?.attributes;
 
-  // useAuth("/login");
+  useAuth("/login");
 
   const isLoading =
     userIsLoading ||

--- a/pages/ssj/[workflow]/index.js
+++ b/pages/ssj/[workflow]/index.js
@@ -12,7 +12,7 @@ import ssjApi from "@api/ssj/ssj";
 import teamsApi from "@api/ssj/teams";
 import processesApi from "@api/workflow/processes";
 import { useUserContext } from "@lib/useUserContext";
-import useAuth from "@lib/utils/useAuth";
+// import useAuth from "@lib/utils/useAuth";
 import { clearLoggedInState, redirectLoginProps } from "@lib/handleLogout";
 import Milestone from "../../../components/Milestone";
 import Task from "../../../components/Task";
@@ -116,7 +116,7 @@ const SSJ = () => {
   const regionalGrowthLead =
     currentUser?.attributes?.ssj?.regionalGrowthLead?.data?.attributes;
 
-  useAuth("/login");
+  // useAuth("/login");
 
   const isLoading =
     userIsLoading ||

--- a/pages/welcome/confirm-demographic-info.js
+++ b/pages/welcome/confirm-demographic-info.js
@@ -36,6 +36,7 @@ import {
   Radio,
   PageContainer,
 } from "@ui";
+import usePerson from "@hooks/usePerson";
 
 const StyledChatBubble = styled(Box)`
   padding: ${({ theme }) => theme.util.buffer * 4}px;
@@ -64,6 +65,8 @@ const ConfirmDemographicInfo = ({}) => {
   const router = useRouter();
   const { currentUser } = useUserContext();
 
+  const { data: personData, isLoading } = usePerson(currentUser?.id);
+
   const {
     control,
     handleSubmit,
@@ -90,41 +93,27 @@ const ConfirmDemographicInfo = ({}) => {
 
   useEffect(() => {
     if (currentUser) {
-      peopleApi
-        .show(currentUser.id)
-        .then((response) => {
-          const person = response.data.data;
-          // console.log("person", person);
-          // SAVEPOINT this request is working.  need to make sure data is persisted and returned
-          // and then loaded into form.  then we are done here.
-          reset({
-            primaryLanguage: person?.attributes?.primaryLanguage || "",
-            primaryLanguageOther:
-              person?.attributes?.primaryLanguageOther || "",
-            raceEthnicity: person?.attributes?.raceEthnicityList || [],
-            raceEthnicityOther: person?.attributes?.raceEthnicityOther || "",
-            lgbtqia: person?.attributes?.lgbtqia,
-            gender: person?.attributes?.gender || "",
-            genderOther: person?.attributes?.genderOther || "",
-            pronouns: person?.attributes?.pronouns || "",
-            pronounsOther: person?.attributes?.pronounsOther || "",
-            householdIncome: person?.attributes?.householdIncome || "",
-            montessoriCertified: person?.attributes?.montessoriCertified || "",
-            montessoriCertifiedLevels:
-              person?.attributes?.montessoriCertifiedLevelList || [],
-            classroomAge: person?.attributes?.classroomAgeList || [],
-          });
-        })
-        .catch((error) => {
-          if (error?.response?.status === 401) {
-            clearLoggedInState({});
-            router.push("/login");
-          } else {
-            console.error(error);
-          }
-        });
+      reset({
+        primaryLanguage: personData?.data?.attributes?.primaryLanguage || "",
+        primaryLanguageOther:
+          personData?.data?.attributes?.primaryLanguageOther || "",
+        raceEthnicity: personData?.data?.attributes?.raceEthnicityList || [],
+        raceEthnicityOther:
+          personData?.data?.attributes?.raceEthnicityOther || "",
+        lgbtqia: personData?.data?.attributes?.lgbtqia,
+        gender: personData?.data?.attributes?.gender || "",
+        genderOther: personData?.data?.attributes?.genderOther || "",
+        pronouns: personData?.data?.attributes?.pronouns || "",
+        pronounsOther: personData?.data?.attributes?.pronounsOther || "",
+        householdIncome: personData?.data?.attributes?.householdIncome || "",
+        montessoriCertified:
+          personData?.data?.attributes?.montessoriCertified || "",
+        montessoriCertifiedLevels:
+          personData?.data?.attributes?.montessoriCertifiedLevelList || [],
+        classroomAge: personData?.data?.attributes?.classroomAgeList || [],
+      });
     }
-  }, [currentUser]);
+  }, [currentUser, isLoading]);
 
   const onSubmit = (data) => {
     // console.log("classroomAge: ", data.classroomAge);

--- a/pages/welcome/confirm-your-details.js
+++ b/pages/welcome/confirm-your-details.js
@@ -23,6 +23,7 @@ import {
   PageContainer,
   Select,
 } from "@ui";
+import usePerson from "@hooks/usePerson";
 
 const StyledChatBubble = styled(Box)`
   padding: ${({ theme }) => theme.util.buffer * 4}px;
@@ -51,6 +52,8 @@ const ConfirmYourDetails = ({}) => {
   const router = useRouter();
   const { currentUser, setCurrentUser } = useUserContext();
 
+  const { data: personData, isLoading } = usePerson(currentUser?.id);
+
   const {
     control,
     handleSubmit,
@@ -69,19 +72,15 @@ const ConfirmYourDetails = ({}) => {
 
   useEffect(() => {
     if (currentUser) {
-      peopleApi.show(currentUser.id).then((response) => {
-        const person = response.data.data;
-        // console.log({ person });
-        reset({
-          firstName: person?.attributes.firstName,
-          lastName: person?.attributes.lastName,
-          city: currentUser?.personAddress.city,
-          state: currentUser?.personAddress.state,
-          email: person?.attributes.email,
-        });
+      reset({
+        firstName: personData?.data?.attributes?.firstName,
+        lastName: personData?.data?.attributes?.firstName,
+        city: currentUser?.personAddress?.city,
+        state: currentUser?.personAddress?.state,
+        email: personData?.data?.attributes?.email,
       });
     }
-  }, [currentUser]);
+  }, [currentUser, isLoading]);
 
   const onSubmit = (data) => {
     const downcasedEmail = data.email.toLowerCase();

--- a/pages/welcome/existing-member/confirm-demographic-info.js
+++ b/pages/welcome/existing-member/confirm-demographic-info.js
@@ -35,6 +35,7 @@ import {
   Radio,
   PageContainer,
 } from "@ui";
+import usePerson from "@hooks/usePerson";
 
 const StyledChatBubble = styled(Box)`
   padding: ${({ theme }) => theme.util.buffer * 4}px;
@@ -63,6 +64,8 @@ const ConfirmDemographicInfo = ({}) => {
   const router = useRouter();
   const { currentUser } = useUserContext();
 
+  const { data: personData, isLoading } = usePerson(currentUser?.id);
+
   const {
     control,
     handleSubmit,
@@ -90,32 +93,29 @@ const ConfirmDemographicInfo = ({}) => {
 
   useEffect(() => {
     if (currentUser) {
-      peopleApi.show(currentUser.id).then((response) => {
-        const person = response.data.data;
-        // console.log("person", person);
-        // SAVEPOINT this request is working.  need to make sure data is persisted and returned
-        // and then loaded into form.  then we are done here.
-        reset({
-          primaryLanguage: person?.attributes?.primaryLanguage || "",
-          primaryLanguageOther: person?.attributes?.primaryLanguageOther || "",
-          raceEthnicity: person?.attributes?.raceEthnicityList || [],
-          raceEthnicityOther: person?.attributes?.raceEthnicityOther || "",
-          lgbtqia: person?.attributes?.lgbtqia,
-          gender: person?.attributes?.gender || "",
-          genderOther: person?.attributes?.genderOther || "",
-          pronouns: person?.attributes?.pronouns || "",
-          pronounsOther: person?.attributes?.pronounsOther || "",
-          householdIncome: person?.attributes?.householdIncome || "",
-          montessoriCertified: person?.attributes?.montessoriCertified || "",
-          montessoriCertifiedLevels:
-            person?.attributes?.montessoriCertifiedLevelList || [],
-          classroomAge: person?.attributes?.classroomAgeList || [],
-          role: person?.attributes?.roleList || [],
-          is_onboarded: true,
-        });
+      reset({
+        primaryLanguage: personData?.data?.attributes?.primaryLanguage || "",
+        primaryLanguageOther:
+          personData?.data?.attributes?.primaryLanguageOther || "",
+        raceEthnicity: personData?.data?.attributes?.raceEthnicityList || [],
+        raceEthnicityOther:
+          personData?.data?.attributes?.raceEthnicityOther || "",
+        lgbtqia: personData?.data?.attributes?.lgbtqia,
+        gender: personData?.data?.attributes?.gender || "",
+        genderOther: personData?.data?.attributes?.genderOther || "",
+        pronouns: personData?.data?.attributes?.pronouns || "",
+        pronounsOther: personData?.data?.attributes?.pronounsOther || "",
+        householdIncome: personData?.data?.attributes?.householdIncome || "",
+        montessoriCertified:
+          personData?.data?.attributes?.montessoriCertified || "",
+        montessoriCertifiedLevels:
+          personData?.data?.attributes?.montessoriCertifiedLevelList || [],
+        classroomAge: personData?.data?.attributes?.classroomAgeList || [],
+        role: personData?.data?.attributes?.roleList || [],
+        is_onboarded: true,
       });
     }
-  }, [currentUser]);
+  }, [currentUser, isLoading]);
 
   const onSubmit = (data) => {
     // console.log("classroomAge: ", data.classroomAge);

--- a/pages/welcome/existing-member/confirm-your-details.js
+++ b/pages/welcome/existing-member/confirm-your-details.js
@@ -22,6 +22,7 @@ import {
   PageContainer,
   Select,
 } from "@ui";
+import usePerson from "@hooks/usePerson";
 
 const StyledChatBubble = styled(Box)`
   padding: ${({ theme }) => theme.util.buffer * 4}px;
@@ -50,7 +51,7 @@ const ConfirmYourDetails = ({}) => {
   const router = useRouter();
   const { currentUser, setCurrentUser } = useUserContext();
 
-  // console.log({ currentUser });
+  const { data: personData, isLoading } = usePerson(currentUser?.id);
 
   const {
     control,
@@ -70,19 +71,15 @@ const ConfirmYourDetails = ({}) => {
 
   useEffect(() => {
     if (currentUser) {
-      peopleApi.show(currentUser.id).then((response) => {
-        const person = response.data.data;
-        // console.log({ person });
-        reset({
-          firstName: person?.attributes.firstName,
-          lastName: person?.attributes.lastName,
-          city: currentUser?.personAddress.city,
-          state: currentUser?.personAddress.state,
-          email: person?.attributes.email,
-        });
+      reset({
+        firstName: personData?.data?.attributes?.firstName,
+        lastName: personData?.data?.attributes?.firstName,
+        city: currentUser?.personAddress?.city,
+        state: currentUser?.personAddress?.state,
+        email: personData?.data?.attributes?.email,
       });
     }
-  }, [currentUser]);
+  }, [currentUser, isLoading]);
 
   const onSubmit = (data) => {
     const downcasedEmail = data.email.toLowerCase();


### PR DESCRIPTION
### Summary 

After updating much of the data fetching to useSWR some of the `put` api calls, [most](https://app.highlight.io/5415/sessions/b7S0aCD6QcmMS3XP5fR1XzG4B2J4?network-resource-id=7&page=1&query=and%7C%7Ccustom_processed%2Cis%2Ctrue) [notably](https://app.highlight.io/5415/sessions/m5cpPyxS47FEWp8YhWnUuDFxbyCq?network-resource-id=42&page=1&query=and%7C%7Ccustom_processed%2Cis%2Ctrue) those in `api/steps` would erroneously log the user out when an trying to assign a task. 

This PR moves the definition of `config` directly into each individual API call rather than globally doing so in `base` and also ensures that all `put` calls are passed an empty object for params so that the call doesn't fail.
