### PR TITLE
Make certain pages load faster

### DIFF
--- a/cypress/e2e/onboarding.cy.js
+++ b/cypress/e2e/onboarding.cy.js
@@ -242,7 +242,7 @@ describe("onboarding spec", () => {
         cy.contains("Foundation Partner").click({ force: true });
         cy.get("body").click(0, 0); // close dropdwon
 
-        cy.get('button[type="submit"]').click();
+        cy.get('button[type="submit"]').click({force: true});
         cy.url({ timeout: 60000 }).should(
           "include",
           "/welcome/existing-member/add-profile-info"

--- a/pages/ssj/[workflow]/[phase]/index.js
+++ b/pages/ssj/[workflow]/[phase]/index.js
@@ -44,6 +44,7 @@ const PhasePage = () => {
     isValidating,
   } = useMilestones(workflow, {
     phase: phase,
+    omit_include: true,
   });
   // console.log({ milestonesByCurrentPhase });
   // console.log({ isLoadingMilestonesByCurrentPhase });

--- a/pages/ssj/[workflow]/milestones.js
+++ b/pages/ssj/[workflow]/milestones.js
@@ -83,8 +83,10 @@ const Milestones = ({}) => {
 export default Milestones;
 
 const MilestonesByCategory = ({ workflow }) => {
-  const { isLoadingMilestonesByCategory, milestonesByCategory } =
-    useMilestones(workflow);
+  const { isLoadingMilestonesByCategory, milestonesByCategory } = useMilestones(
+    workflow,
+    { omit_include: true }
+  );
   return isLoadingMilestonesByCategory ? (
     <Stack spacing={6}>
       {Array.from({ length: 12 }, (_, i) => (


### PR DESCRIPTION
When pairing with @taylorz I noticed some pages were frustratingly slow. These are some time changes tested locally on my machine, pointing to production API.
 
`/ssj/[workflow]/startup`: 889 ms -> 259 ms (3.4x faster)
`/ssj/[workflow]/visioning`: 306 ms -> 119 ms (2.5x faster)
`/ssj/[workflow]/visioning`: 722 ms -> 202 ms (3.5x faster)
`/ssj/[workflow]/milestones`: 1.6 s -> 252 ms (6.3x faster)
