### PR TITLE
[hotfix] nav isTeacherLeader check update for affiliated ETLs

### DIFF
--- a/components/Nav.js
+++ b/components/Nav.js
@@ -113,8 +113,8 @@ const Navigation = () => {
   }, []);
 
   const isTeacherLeader =
-    currentUser?.personRoleList?.includes("Teacher Leader");
-
+    currentUser?.personRoleList?.join() === ["Teacher Leader"].join() &&
+    !currentUser?.personRoleList?.includes("Emerging Teacher Leader");
   // console.log({ ogViewingSchool });
   // console.log({ isTeacherLeader });
   // console.log({ currentUser });


### PR DESCRIPTION
check to see if a role list has both ETL and TL in it before showing nav items