### PR TITLE
[Backmerge] Fix affiliated ETLs seeing open school dash

### DIFF
--- a/components/Nav.js
+++ b/components/Nav.js
@@ -113,8 +113,8 @@ const Navigation = () => {
   }, []);
 
   const isTeacherLeader =
-    currentUser?.personRoleList?.includes("Teacher Leader");
-
+    currentUser?.personRoleList?.join() === ["Teacher Leader"].join() &&
+    !currentUser?.personRoleList?.includes("Emerging Teacher Leader");
   // console.log({ ogViewingSchool });
   // console.log({ isTeacherLeader });
   // console.log({ currentUser });


### PR DESCRIPTION
We add "Teacher Leader" to an ETL's role after affiliation, but we dont want to show them the open school dash yet. 