### PR TITLE
Update logic for defining position in admin workflow ux

### DIFF
--- a/pages/admin/workflows/[workflowId]/index.js
+++ b/pages/admin/workflows/[workflowId]/index.js
@@ -70,7 +70,7 @@ const Workflow = ({}) => {
   // console.log({ workflowId });
 
   const { workflow, isLoading, isError } = useWorkflow(workflowId);
-  // console.log({ workflow });
+  console.log({ workflow });
 
   const rolloutInProgress =
     workflow?.attributes.rolloutStartedAt !== null &&
@@ -415,6 +415,7 @@ const Workflow = ({}) => {
                         }
                         renderItem={(process, i) => (
                           <ProcessListItem
+                            workflow={workflow}
                             disabled={
                               rolloutInProgress ||
                               workflow?.attributes.needsSupport
@@ -585,6 +586,7 @@ const AddProcessModal = ({
 };
 
 const ProcessListItem = ({
+  workflow,
   isDraftingNewVersion,
   handleStageAddProcess,
   handleRemoveProcess,
@@ -600,10 +602,31 @@ const ProcessListItem = ({
     process.relationships.selectedProcesses?.data[0].attributes.state;
   const selectedProcesses = process.relationships.selectedProcesses?.data;
 
-  const processPosition =
+  let processPosition =
     (selectedProcesses[0].attributes.position + prevProcessPosition) / 2;
-  // console.log({ processPosition });
-  const lastProcessPosition = selectedProcesses[0].attributes.position + 1000;
+  let lastProcessPosition = selectedProcesses[0].attributes.position + 1000;
+
+  if (
+    //check for duplicate position in selectedProcess, and if so, add 2
+    workflow.relationships.processes.data.some(
+      (process) =>
+        process.relationships.selectedProcesses.data[0].attributes.position ===
+        processPosition
+    )
+  ) {
+    processPosition += 2;
+  }
+
+  if (
+    //check for duplicate position in selectedProcess, and if so, add 2
+    workflow.relationships.processes.data.some(
+      (process) =>
+        process.relationships.selectedProcesses.data[0].attributes.position ===
+        lastProcessPosition
+    )
+  ) {
+    lastProcessPosition += 2;
+  }
 
   const isRemoved = selectedProcesses.some(
     (process) => process.attributes.state === "removed"
@@ -611,6 +634,8 @@ const ProcessListItem = ({
 
   const numOfPrerequisites = process?.attributes.prerequisiteTitles.length;
 
+  // console.log(processPosition);
+  // console.log(lastProcessPosition);
   // console.log({ process });
   // console.log({ prevProcessPosition });
   // console.log(process.attributes.title, {

--- a/pages/admin/workflows/[workflowId]/index.js
+++ b/pages/admin/workflows/[workflowId]/index.js
@@ -70,7 +70,7 @@ const Workflow = ({}) => {
   // console.log({ workflowId });
 
   const { workflow, isLoading, isError } = useWorkflow(workflowId);
-  console.log({ workflow });
+  // console.log({ workflow });
 
   const rolloutInProgress =
     workflow?.attributes.rolloutStartedAt !== null &&
@@ -602,30 +602,26 @@ const ProcessListItem = ({
     process.relationships.selectedProcesses?.data[0].attributes.state;
   const selectedProcesses = process.relationships.selectedProcesses?.data;
 
-  let processPosition =
+  const currentProcessIndex = workflow.relationships.processes.data.findIndex(
+    (process) =>
+      process.relationships.selectedProcesses.data[0].id ===
+      selectedProcesses[0].id
+  );
+  const subsequentProcess =
+    workflow.relationships.processes.data[currentProcessIndex + 1];
+
+  const processPosition =
     (selectedProcesses[0].attributes.position + prevProcessPosition) / 2;
-  let lastProcessPosition = selectedProcesses[0].attributes.position + 1000;
 
-  if (
-    //check for duplicate position in selectedProcess, and if so, add 2
-    workflow.relationships.processes.data.some(
-      (process) =>
-        process.relationships.selectedProcesses.data[0].attributes.position ===
-        processPosition
-    )
-  ) {
-    processPosition += 2;
-  }
-
-  if (
-    //check for duplicate position in selectedProcess, and if so, add 2
-    workflow.relationships.processes.data.some(
-      (process) =>
-        process.relationships.selectedProcesses.data[0].attributes.position ===
-        lastProcessPosition
-    )
-  ) {
-    lastProcessPosition += 2;
+  let lastProcessPosition;
+  if (subsequentProcess) {
+    lastProcessPosition =
+      (selectedProcesses[0].attributes.position +
+        subsequentProcess.relationships.selectedProcesses.data[0].attributes
+          .position) /
+      2;
+  } else {
+    lastProcessPosition = selectedProcesses[0].attributes.position + 1000;
   }
 
   const isRemoved = selectedProcesses.some(
@@ -634,6 +630,8 @@ const ProcessListItem = ({
 
   const numOfPrerequisites = process?.attributes.prerequisiteTitles.length;
 
+  // console.log({ currentProcessIndex });
+  // console.log({ subsequentProcess });
   // console.log(processPosition);
   // console.log(lastProcessPosition);
   // console.log({ process });


### PR DESCRIPTION
Addresses issue where sometimes duplicate `positions` would be created when users would add a process at the end of a phase. This was due to the previous calculation simply adding `1000`, rather than calculating the mid point between the last process in the phase, and the first process in the next phase.
