### PR TITLE
Build choose position when changing phase on `processId`

### DIFF
--- a/pages/admin/workflows/processes/[processId]/index.js
+++ b/pages/admin/workflows/processes/[processId]/index.js
@@ -138,10 +138,7 @@ const ProcessId = ({}) => {
     // Remove unchanged data
     const updatedData = Object.keys(data).reduce((acc, key) => {
       if (data[key] !== originalData[key]) {
-        if (
-          (key === "category_list" || key === "phase_list") &&
-          !Array.isArray(data[key])
-        ) {
+        if (key === "category_list" && !Array.isArray(data[key])) {
           acc[key] = [data[key]];
         } else {
           acc[key] = data[key];
@@ -299,7 +296,7 @@ const ProcessId = ({}) => {
     // console.log(position);
     const structuredData = {
       process: {
-        phase_list: [`${phase}`],
+        phase_list: phase,
         selected_processes_attributes: [
           {
             workflow_id: workflow.id,
@@ -309,6 +306,7 @@ const ProcessId = ({}) => {
         ],
       },
     };
+    console.log({ structuredData });
     setUpdateProcessPositionData(structuredData);
   };
 

--- a/pages/admin/workflows/processes/[processId]/index.js
+++ b/pages/admin/workflows/processes/[processId]/index.js
@@ -295,32 +295,21 @@ const ProcessId = ({}) => {
     }
   }, [phaseListField]);
 
-  const handleChoosePosition = async (position, phase) => {
+  const handleChoosePosition = async (position, phase, selectedProcessId) => {
     // console.log(position);
     const structuredData = {
       process: {
         phase_list: [`${phase}`],
         selected_processes_attributes: [
-          { workflow_id: workflow.id, position: position },
+          {
+            workflow_id: workflow.id,
+            position: position,
+            id: selectedProcessId,
+          },
         ],
       },
     };
     setUpdateProcessPositionData(structuredData);
-    // console.log({ structuredData });
-    // try {
-    //   const response = await processApi.editMilestone(
-    //     processId,
-    //     structuredData
-    //   );
-    //   mutate(`definition/workflows/${workflowId}/processes/${processId}`);
-    //   setShowChoosePositionModal((prevState) => ({
-    //     ...prevState,
-    //     state: false,
-    //     intent: false,
-    //   }));
-    // } catch (error) {
-    //   console.log(error);
-    // }
   };
 
   return (
@@ -1198,12 +1187,18 @@ const ChoosePositionModal = ({
 }) => {
   // console.log(stagedPhase);
 
+  console.log({ milestone });
+
+  const currentProcessSelectedProcessId =
+    milestone?.relationships.selectedProcesses.data[0].id;
+
   return (
     <Dialog open={open} fullWidth>
       <DialogTitle>Choose new position</DialogTitle>
       <DialogContent>
         <Card sx={{ overflow: "visible", padding: 0 }}>
           <ChoosePositionList
+            currentProcessSelectedProcessId={currentProcessSelectedProcessId}
             onClose={onClose}
             stagedPhase={stagedPhase}
             workflow={workflow}
@@ -1221,6 +1216,7 @@ const ChoosePositionList = ({
   workflow,
   handleChoosePosition,
   onClose,
+  currentProcessSelectedProcessId,
 }) => {
   const stagedPhaseProcessesArray =
     workflow.relationships.processes.data.filter(
@@ -1247,6 +1243,7 @@ const ChoosePositionList = ({
     >
       {stagedPhaseProcessesArray.map((process, i) => (
         <ChoosePositionListItem
+          currentProcessSelectedProcessId={currentProcessSelectedProcessId}
           onClose={onClose}
           isLast={i === stagedPhaseProcessesArray.length - 1}
           workflow={workflow}
@@ -1267,6 +1264,7 @@ const ChoosePositionListItem = ({
   isLast,
   phase,
   onClose,
+  currentProcessSelectedProcessId,
 }) => {
   // console.log({ workflow });
 
@@ -1303,6 +1301,7 @@ const ChoosePositionListItem = ({
   }
 
   // console.log(processPosition);
+  // console.log(selectedProcesses);
   // console.log(lastProcessPosition);
 
   return (
@@ -1313,11 +1312,19 @@ const ChoosePositionListItem = ({
         id={`inline-action-tile-${snakeCase(process.attributes.title)}`}
         showAdd={true}
         add={() => {
-          handleChoosePosition(processPosition, phase);
+          handleChoosePosition(
+            processPosition,
+            phase,
+            currentProcessSelectedProcessId
+          );
           onClose();
         }}
         lastAdd={() => {
-          handleChoosePosition(lastProcessPosition, phase);
+          handleChoosePosition(
+            lastProcessPosition,
+            phase,
+            currentProcessSelectedProcessId
+          );
           onClose();
         }}
       />

--- a/pages/admin/workflows/processes/[processId]/index.js
+++ b/pages/admin/workflows/processes/[processId]/index.js
@@ -146,8 +146,8 @@ const ProcessId = ({}) => {
       }
       return acc;
     }, {});
-    console.log({ updatedData });
-    console.log({ updateProcessPositionData });
+    // console.log({ updatedData });
+    // console.log({ updateProcessPositionData });
 
     if (updateProcessPositionData) {
       updatedData.selected_processes_attributes =
@@ -238,7 +238,7 @@ const ProcessId = ({}) => {
       const response = await workflowApi.reinstateProcessInWorkflow(
         selectedProcessId
       );
-      console.log({ response });
+      // console.log({ response });
       router.push(
         `/admin/workflows/processes/${response.data.data.attributes.processId}`
       );
@@ -273,7 +273,7 @@ const ProcessId = ({}) => {
   };
 
   const handleDeleteDependency = async (dependencyId) => {
-    console.log("Delete dependency", dependencyId);
+    // console.log("Delete dependency", dependencyId);
     try {
       const response = await workflowApi.deleteDependency(dependencyId);
       mutate(`definition/workflows/${workflowId}/processes/${processId}`);
@@ -306,7 +306,7 @@ const ProcessId = ({}) => {
         ],
       },
     };
-    console.log({ structuredData });
+    // console.log({ structuredData });
     setUpdateProcessPositionData(structuredData);
   };
 
@@ -1184,8 +1184,6 @@ const ChoosePositionModal = ({
   stagedPhase,
 }) => {
   // console.log(stagedPhase);
-
-  console.log({ milestone });
 
   const currentProcessSelectedProcessId =
     milestone?.relationships.selectedProcesses.data[0].id;


### PR DESCRIPTION
- include new UX for choosing the position a process should land in when phase is changed in rollout