### PR TITLE
redirect to the affiliated, current, school for teachers

### DIFF
--- a/components/AssigneeRoster.js
+++ b/components/AssigneeRoster.js
@@ -61,11 +61,11 @@ const AssigneeRoster = ({
 
   const cantAssign = completionType === "one_per_group" && completers.length;
 
-  console.log({ completers });
+  // console.log({ completers });
   // console.log({ assignees });
-  console.log({ completionType });
-  console.log({ assignableUsers });
-  console.log({ cantAssign });
+  // console.log({ completionType });
+  // console.log({ assignableUsers });
+  // console.log({ cantAssign });
 
   return (
     <>

--- a/components/Header.js
+++ b/components/Header.js
@@ -29,7 +29,10 @@ const Header = ({ toggleNavOpen }) => {
 
   const logo = "/assets/images/wildflower-logo.png";
 
-  const showNetwork = !currentUser?.attributes?.ssj;
+  const showNetwork = !(
+    currentUser?.personRoleList?.includes("Emerging Teacher Leader") &&
+    !currentUser?.personRoleList?.includes("Teacher Leader")
+  );
 
   // console.log({ currentUser });
   // console.log({ isAdmin });

--- a/components/Nav.js
+++ b/components/Nav.js
@@ -193,8 +193,12 @@ const Navigation = () => {
               variant="primary"
               to="/open-school"
               active={router.asPath === `/open-school/${workflow}`}
-              label="Open School"
-              // label={currentUser?.attributes.schools[0].name}
+              // label="Open School"
+              label={
+                currentUser?.attributes.schools.find(
+                  (school) => school.workflowId === workflow
+                )?.name
+              }
               icon="home"
             />
           ) : null}

--- a/components/Nav.js
+++ b/components/Nav.js
@@ -99,7 +99,13 @@ const Navigation = () => {
   const router = useRouter();
   const { currentUser, isOperationsGuide } = useUserContext();
   const [ogViewingSchool, setOgViewingSchool] = useState();
+  const [mySchoolWorkflowId, setMySchoolWorkflowId] = useState();
   const { workflow } = router.query;
+
+  useEffect(() => {
+    sessionStorage.getItem("mySchoolWorkflowId") &&
+      setMySchoolWorkflowId(sessionStorage.getItem("mySchoolWorkflowId"));
+  }, []);
 
   useEffect(() => {
     if (router.asPath === "/your-schools") {
@@ -192,11 +198,11 @@ const Navigation = () => {
             <NavLink
               variant="primary"
               to="/open-school"
-              active={router.asPath === `/open-school/${workflow}`}
+              active={router.asPath === `/open-school/${mySchoolWorkflowId}`}
               // label="Open School"
               label={
                 currentUser?.attributes.schools.find(
-                  (school) => school.workflowId === workflow
+                  (school) => school.workflowId === mySchoolWorkflowId
                 )?.name
               }
               icon="home"
@@ -205,7 +211,7 @@ const Navigation = () => {
 
           {router.pathname.includes("/open-school") ? (
             <OpenSchoolNavigation
-              openSchoolWorkflowId={workflow}
+              openSchoolWorkflowId={mySchoolWorkflowId}
               currentUserId={currentUser?.id}
               currentUserEmail={currentUser?.attributes.email}
             />

--- a/components/Task.js
+++ b/components/Task.js
@@ -91,6 +91,7 @@ const Task = ({
     const { data: school, isLoading: schoolIsLoading } =
       useSchool(userSchoolId);
     if (!schoolIsLoading) {
+      console.log({ school });
       assignableUsers = school?.included.filter(
         (item) => item.type === "person"
       );

--- a/components/Task.js
+++ b/components/Task.js
@@ -91,10 +91,17 @@ const Task = ({
     const { data: school, isLoading: schoolIsLoading } =
       useSchool(userSchoolId);
     if (!schoolIsLoading) {
-      console.log({ school });
-      assignableUsers = school?.included.filter(
-        (item) => item.type === "person"
-      );
+      assignableUsers = school?.included.filter((item) => {
+        if (item.type === "person" && item.attributes.isOnboarded === true) {
+          return school.included.some(
+            (relationship) =>
+              relationship.type === "schoolRelationship" &&
+              relationship.relationships.person.data.id === item.id &&
+              relationship.attributes.endDate === null
+          );
+        }
+        return false;
+      });
     }
   } else if (router.pathname.startsWith("/ssj/")) {
     // If the current route starts with '/ssj/', fetch the team's data and use it to set assignableUsers
@@ -112,7 +119,7 @@ const Task = ({
   // Always call out the constants here and never directly pull from task.attributes in the UI; except unless you are setting default state in a useState hook.
   // If you have props that depend on where they are being called from, put them as inputs for Task
 
-  console.log({ task });
+  // console.log({ task });
   // console.log({ assignableUsers });
 
   const taskId = task.id;

--- a/pages/network/schools/[schoolId]/index.js
+++ b/pages/network/schools/[schoolId]/index.js
@@ -1475,9 +1475,7 @@ const TeacherLeaderFields = ({ handleToggle, school }) => {
   };
 
   const teacherLeaderRelationships = schoolData?.included?.filter(
-    (rel) =>
-      rel.type === "schoolRelationship" &&
-      rel.attributes.roleList.includes("Teacher Leader")
+    (rel) => rel.type === "schoolRelationship"
   );
 
   const teachers = schoolData?.included
@@ -1507,10 +1505,18 @@ const TeacherLeaderFields = ({ handleToggle, school }) => {
 
   const watchFields = watch();
 
+  const sortedTeachers = teachers.sort((a, b) => {
+    return a.attributes.isOnboarded === b.attributes.isOnboarded
+      ? 0
+      : a.attributes.isOnboarded
+      ? -1
+      : 1;
+  });
+
   console.log(watchFields.dateJoined);
 
   // console.log({ results });
-  // console.log({ teachers });
+  console.log({ teachers });
   // console.log({ currentTeacher });
 
   return (
@@ -1725,7 +1731,7 @@ const TeacherLeaderFields = ({ handleToggle, school }) => {
                       </Grid>
                     </Card>
                   </Grid>
-                  {teachers.map((teacher, i) => (
+                  {sortedTeachers.map((teacher, i) => (
                     <Grid item xs={12} key={i}>
                       <Grid
                         container
@@ -1735,19 +1741,25 @@ const TeacherLeaderFields = ({ handleToggle, school }) => {
                         spacing={3}
                       >
                         <Grid item xs={8}>
-                          <Typography
-                            variant="bodyRegular"
-                            bold
-                            noWrap
-                            style={{
-                              overflow: "hidden",
-                              textOverflow: "ellipsis",
-                              whiteSpace: "nowrap",
-                            }}
-                          >
-                            {teacher.attributes.firstName}{" "}
-                            {teacher.attributes.lastName}
-                          </Typography>
+                          <Stack direction="row" spacing={2}>
+                            <Typography
+                              variant="bodyRegular"
+                              lightened={!teacher.attributes.isOnboarded}
+                              bold
+                              noWrap
+                              style={{
+                                overflow: "hidden",
+                                textOverflow: "ellipsis",
+                                whiteSpace: "nowrap",
+                              }}
+                            >
+                              {teacher.attributes.firstName}{" "}
+                              {teacher.attributes.lastName}
+                            </Typography>
+                            {teacher.attributes.isOnboarded === false ? (
+                              <Chip label="Invited" size="small" />
+                            ) : null}
+                          </Stack>
                         </Grid>
                         <Grid item alignItems="flex-end">
                           <Stack direction="row" spacing={3}>

--- a/pages/open-school/index.js
+++ b/pages/open-school/index.js
@@ -22,6 +22,7 @@ const OpenSchoolWorkflow = ({}) => {
   useEffect(() => {
     if (schoolWorkflowId) {
       router.push(`/open-school/${schoolWorkflowId}`);
+      sessionStorage.setItem("mySchoolWorkflowId", schoolWorkflowId);
     }
   }, [currentUser]);
 

--- a/pages/open-school/index.js
+++ b/pages/open-school/index.js
@@ -12,7 +12,12 @@ const OpenSchoolWorkflow = ({}) => {
   const router = useRouter();
 
   const { currentUser } = useUserContext();
-  const schoolWorkflowId = currentUser?.attributes?.schools[0]?.workflowId;
+
+  const currentSchool = currentUser?.attributes?.schools.filter(
+    (s) => s.affiliated === true && s.end_date === null
+  );
+
+  const schoolWorkflowId = currentSchool && currentSchool[0]?.workflowId;
 
   useEffect(() => {
     if (schoolWorkflowId) {


### PR DESCRIPTION
- add "mySchool" workflowId to session storage to retrieve on pages where workflowId is not in router.query
- adjustments to header menu showing network link only if ETL and nothing else
- adjustments to how assignable users are calculated -- **must be onboarded**
- show "invited" status for teachers who have **not onboarded** on the schoolId page 