### PR TITLE
[hotfix] add ssr for translation strings on necessary pages within osc

### DIFF
--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -3,7 +3,6 @@ module.exports = {
   i18n: {
     defaultLocale: "en",
     locales: ["en", "es"],
-    fallbackLng: "en",
   },
   localePath: path.resolve("./public/locales"),
   returnEmptyString: false, // Treat empty strings as missing keys

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,5 @@
 const { withHighlightConfig } = require("@highlight-run/next/config");
 const { i18n } = require("./next-i18next.config");
-const path = require("path");
 
 module.exports = withHighlightConfig({
   reactStrictMode: true,
@@ -12,5 +11,4 @@ module.exports = withHighlightConfig({
       process.env.NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID,
   },
   i18n,
-  localePath: path.resolve("./public/locales"),
 });

--- a/pages/open-school/[workflow]/checklist/[year]/[month]/[milestone]/index.js
+++ b/pages/open-school/[workflow]/checklist/[year]/[month]/[milestone]/index.js
@@ -128,3 +128,14 @@ const OpenSchoolMilestonePage = ({}) => {
 };
 
 export default OpenSchoolMilestonePage;
+
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+
+export async function getServerSideProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ["common"])),
+      // Add any additional props you need to pass to the page component
+    },
+  };
+}

--- a/pages/open-school/[workflow]/checklist/[year]/[month]/index.js
+++ b/pages/open-school/[workflow]/checklist/[year]/[month]/index.js
@@ -585,3 +585,14 @@ const MilestoneGroup = ({ workflowId, milestones, periodName }) => {
     </>
   );
 };
+
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+
+export async function getServerSideProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ["common"])),
+      // Add any additional props you need to pass to the page component
+    },
+  };
+}


### PR DESCRIPTION
as translations for categories and phases are shared within the phaseChip and categoryChip components, ensuring the translation strings from common json files load with correct imports within the OSC