### PR TITLE
[hotfix] get the workflow value from the route, not a currentUser obj

### DIFF
--- a/pages/open-school/[workflow]/checklist/[year]/[month]/index.js
+++ b/pages/open-school/[workflow]/checklist/[year]/[month]/index.js
@@ -40,9 +40,11 @@ const AdminChecklist = () => {
   const { screenSize } = getScreenSize();
   const { currentUser } = useUserContext();
   const router = useRouter();
-  const workflowId = currentUser?.attributes.schools[0].workflowId;
-
-  const { year: yearQuery, month: monthQuery } = router.query;
+  const {
+    year: yearQuery,
+    month: monthQuery,
+    workflow: workflowId,
+  } = router.query;
 
   const [isToday, setIsToday] = useState(false);
 


### PR DESCRIPTION
on the open school checklist page, get the workflowId from the router instead of currentUser obj