### PR TITLE
[hotfix] various bug fixes

### DIFF
--- a/pages/admin/people/[personId].js
+++ b/pages/admin/people/[personId].js
@@ -1141,7 +1141,11 @@ const RemovePersonModal = ({ open, onClose, personName }) => {
   });
 
   const confirmName = watch("confirmName");
-  const isNameConfirmed = confirmName === personName;
+  // Normalize spaces in both the input and the stored name
+  const normalizeSpaces = (str) => str.replace(/\s+/g, " ").trim();
+  const normalizedConfirmName = normalizeSpaces(confirmName);
+  const normalizedPersonName = normalizeSpaces(personName);
+  const isNameConfirmed = normalizedConfirmName === normalizedPersonName;
   const [error, setError] = useState(null);
 
   useEffect(() => {
@@ -1195,7 +1199,8 @@ const RemovePersonModal = ({ open, onClose, personName }) => {
               rules={{
                 required: "Please type the full name to confirm",
                 validate: (value) =>
-                  value === personName || "Name doesn't match exactly",
+                  normalizeSpaces(value) === normalizedPersonName ||
+                  "Name doesn't match exactly",
               }}
               render={({ field }) => (
                 <TextField

--- a/pages/network/schools/[schoolId]/index.js
+++ b/pages/network/schools/[schoolId]/index.js
@@ -133,7 +133,8 @@ const School = ({}) => {
     const teacherLeaderRelationships = schoolData?.included?.filter(
       (rel) =>
         rel.type === "schoolRelationship" &&
-        rel.attributes.roleList.includes("Teacher Leader") &&
+        (rel.attributes.roleList.includes("Teacher Leader") ||
+          rel.attributes.roleList.includes("Emerging Teacher Leader")) &&
         rel.attributes.startDate &&
         !rel.attributes.endDate
     );

--- a/pages/school/[schoolId]/index.js
+++ b/pages/school/[schoolId]/index.js
@@ -80,7 +80,11 @@ const SchoolPage = () => {
           ...person,
           attributes: {
             ...person.attributes,
-            schoolRoleList: relationship.attributes.roleList,
+            schoolRoleList: relationship.attributes.roleList.map((role) =>
+              role === "Wildflower Support" && relationship.attributes.title
+                ? relationship.attributes.title
+                : role
+            ),
             schoolInvited: isInvitedPartner
               ? true
               : isActivePartner


### PR DESCRIPTION
- fix remove person bug on `admin/people/personId` where double spaces between first and last name caused safe name entry to break
- ensure that even ETLs at unopened schools show up in the directory on their school
- ensure that if a person's role is "Wildflower Support" look for their "title" as defined in admin, and show that if available