### PR TITLE
prevent cache collisions in showSchool, pass default empty array props for assignee props

### DIFF
--- a/api/schools.js
+++ b/api/schools.js
@@ -65,7 +65,23 @@ async function show(id, params = {}) {
 }
 
 export const showSchool = {
-  key: (schoolId, params) => `/v1/schools/${schoolId}`,
+  key: (schoolId, params = {}) => {
+    const entries = Object.entries(params || {});
+    if (!entries.length) return `/v1/schools/${schoolId}`;
+
+    const usp = new URLSearchParams();
+    entries.forEach(([key, value]) => {
+      if (key === "serialization_fields" && Array.isArray(value)) {
+        usp.append(key, value.join(","));
+      } else if (Array.isArray(value)) {
+        value.forEach((v) => usp.append(`${key}[]`, v));
+      } else if (value !== undefined && value !== null) {
+        usp.append(key, value);
+      }
+    });
+    const qs = usp.toString();
+    return qs ? `/v1/schools/${schoolId}?${qs}` : `/v1/schools/${schoolId}`;
+  },
   fetcher: (schoolId, params) => {
     const config = getAuthHeader();
     if (params) {

--- a/components/AssigneeRoster.js
+++ b/components/AssigneeRoster.js
@@ -24,9 +24,9 @@ const StyledAssigneeRoster = styled(Popover)`
 `;
 
 const AssigneeRoster = ({
-  assignees,
-  completers,
-  assignableUsers,
+  assignees = [],
+  completers = [],
+  assignableUsers = [],
   handleAssignUser,
   handleUnassignUser,
   completionType,

--- a/components/InfoDrawer.js
+++ b/components/InfoDrawer.js
@@ -159,7 +159,9 @@ const InfoDrawer = ({
                   <AssigneeRoster
                     handleAssignUser={handleAssignUser}
                     handleUnassignUser={handleUnassignUser}
-                    assignableUsers={assignableUsers}
+                    assignableUsers={
+                      Array.isArray(assignableUsers) ? assignableUsers : []
+                    }
                     assignees={assignees}
                     completers={completers}
                     completionType={completionType}

--- a/components/Task.js
+++ b/components/Task.js
@@ -86,8 +86,6 @@ const Task = ({
 
   let assignableUsers;
 
-  // console.log({ school });
-
   // Only set assignable users once school data is loaded
   if (!schoolIsLoading && school?.included) {
     // First get all active school relationships
@@ -98,8 +96,8 @@ const Task = ({
     // Get the person IDs from the active relationships and map their roles
     const activePersonRoles = schoolRelationships.reduce(
       (acc, relationship) => {
-        acc[relationship.relationships.person.data.id] =
-          relationship.attributes.roleList;
+        const personId = relationship.relationships.person.data.id;
+        acc[personId] = relationship.attributes.roleList;
         return acc;
       },
       {}
@@ -402,7 +400,7 @@ const Task = ({
         completers={taskCompleters}
         handleAssignUser={handleAssignUser}
         handleUnassignUser={handleUnassignUser}
-        assignableUsers={assignableUsers}
+        assignableUsers={Array.isArray(assignableUsers) ? assignableUsers : []}
         completionType={completionType}
         processName={processName}
         actions={


### PR DESCRIPTION
- Updated `api/schools.js` (showSchool.key) to include params in the SWR key to prevent cache collisions
- `AssigneeRoster` prop defaults: `assignees`, `completers`, `assignableUsers` now default to `[]`
